### PR TITLE
Add SearchWidgets vertical slice (query handler + endpoint)

### DIFF
--- a/src/WidgetDepot.ApiService/Features/SearchWidgets/SearchWidgetsQuery.cs
+++ b/src/WidgetDepot.ApiService/Features/SearchWidgets/SearchWidgetsQuery.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.SearchWidgets;
+
+public record SearchWidgetsQuery(string? Term);
+
+public record WidgetResult(
+    int Id,
+    string Sku,
+    string Name,
+    string Description,
+    string Manufacturer,
+    decimal Weight,
+    decimal Price,
+    DateOnly DateAvailable);
+
+public class SearchWidgetsHandler(AppDbContext db)
+{
+    public async Task<IReadOnlyList<WidgetResult>> HandleAsync(SearchWidgetsQuery query)
+    {
+        if (string.IsNullOrWhiteSpace(query.Term))
+            return [];
+
+        var term = query.Term.Trim();
+
+        return await db.Widgets
+            .Where(w => EF.Functions.ILike(w.Name, $"%{term}%") ||
+                        EF.Functions.ILike(w.Description, $"%{term}%"))
+            .Select(w => new WidgetResult(
+                w.Id,
+                w.Sku,
+                w.Name,
+                w.Description,
+                w.Manufacturer,
+                w.Weight,
+                w.Price,
+                w.DateAvailable))
+            .ToListAsync();
+    }
+}

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.SearchWidgets;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -10,6 +11,7 @@ builder.AddServiceDefaults();
 builder.Services.AddProblemDetails();
 
 builder.AddNpgsqlDbContext<AppDbContext>("widgetdepot");
+builder.Services.AddScoped<SearchWidgetsHandler>();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
@@ -34,6 +36,13 @@ if (app.Environment.IsDevelopment())
 string[] summaries = ["Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"];
 
 app.MapGet("/", () => "API service is running. Navigate to /weatherforecast to see sample data.");
+
+app.MapGet("/widgets/search", async (string? term, SearchWidgetsHandler handler) =>
+{
+    var results = await handler.HandleAsync(new SearchWidgetsQuery(term));
+    return Results.Ok(results);
+})
+.WithName("SearchWidgets");
 
 app.MapGet("/weatherforecast", () =>
 {

--- a/test/WidgetDepot.Tests/Features/SearchWidgets/SearchWidgetsHandlerTests.cs
+++ b/test/WidgetDepot.Tests/Features/SearchWidgets/SearchWidgetsHandlerTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.SearchWidgets;
+
+namespace WidgetDepot.Tests.Features.SearchWidgets;
+
+public class SearchWidgetsHandlerTests
+{
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task HandleAsync_NullOrWhitespaceTerm_ReturnsEmpty(string? term)
+    {
+        using var db = CreateDb();
+        db.Widgets.Add(new Widget { Name = "Widget A", Description = "Some description" });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var handler = new SearchWidgetsHandler(db);
+        var results = await handler.HandleAsync(new SearchWidgetsQuery(term));
+
+        Assert.Empty(results);
+    }
+}

--- a/test/WidgetDepot.Tests/WidgetDepot.Tests.csproj
+++ b/test/WidgetDepot.Tests/WidgetDepot.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" Version="13.2.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
     <PackageReference Include="xunit.v3" Version="3.0.1" />
@@ -19,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\WidgetDepot.AppHost\WidgetDepot.AppHost.csproj" />
+    <ProjectReference Include="..\..\src\WidgetDepot.ApiService\WidgetDepot.ApiService.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Adds `SearchWidgets` feature folder under `src/WidgetDepot.ApiService/Features/SearchWidgets/`
- `SearchWidgetsQuery` record accepts an optional search term; `SearchWidgetsHandler` performs case-insensitive `ILike` on `Name` and `Description` via EF Core
- Returns empty when term is null or whitespace
- Registers handler as a scoped service and maps `GET /widgets/search?term=...` in `Program.cs`
- Unit tests cover null, empty, and whitespace term cases

## Test plan
- [ ] Run unit tests: `dotnet test --filter "FullyQualifiedName~SearchWidgets"`
- [ ] Start the Aspire app and call `GET /widgets/search?term=widget` to verify live PostgreSQL results

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/claude-code)