### PR TITLE
Add POST /widgets/import CSV import endpoint

### DIFF
--- a/docs/milestone-01/02-catalog-csv-import.md
+++ b/docs/milestone-01/02-catalog-csv-import.md
@@ -3,29 +3,51 @@
 ## User Story
 
 > As a **warehouse staff member**,
-> I need to load the widget catalog from a CSV file,
+> I need to upload the widget catalog from a CSV file,
 > in order to populate the site with product data at launch.
 
 ## Background
 
-...
+Widget Depot does not manage catalog data directly — the source of truth is the ERP system, which
+exports widget data as a daily CSV batch via FTP. This story covers the initial import capability:
+a staff-facing upload page that parses an ERP-exported CSV and upserts widgets into the database.
+
+The CSV format is fixed by the ERP and contains these columns (in order):
+`SKU, Name, Description, Manufacturer, Weight, Price, Date Available`
+
+The `Widget` entity is already defined in `WidgetDepot.ApiService/Data/Widget.cs`.
 
 ## Scope
 
 **In scope:**
-- ...
+- An authenticated admin page with a file upload control for `.csv` files
+- CSV parsing and per-row validation
+- Upsert logic: insert new widgets; update existing widgets matched by SKU
+- An import summary displayed after upload (rows inserted, rows updated, rows skipped with reasons)
 
 **Out of scope:**
-- ...
+- Scheduled or automated import (future story)
+- Changes to the CSV format or ERP export structure
+- Bulk delete or catalog reset
+- Partial rollback on error (failed rows are skipped; valid rows are committed)
 
 ## Developer Notes
 
-- Relevant file(s): `src/...`
-- Patterns to follow: ...
-- Constraints / things not to change: ...
+- New feature slice: `WidgetDepot.Web/Features/Admin/CatalogImport/`
+- New API endpoint in `WidgetDepot.ApiService/Features/Widgets/Import/`
+- The import endpoint receives a multipart form upload and returns a summary DTO
+- Use EF Core upsert via `ExecuteUpdateAsync` or `AddOrUpdate` pattern keyed on `Sku`
+- CSV parsing: use `CsvHelper` or plain `StreamReader` line-by-line — no third-party dependency required for a fixed-format file
+- Auth is bypassed locally; the page does not need an auth guard for this milestone
+- The `DateAvailable` column maps to `DateOnly` — parse with `DateOnly.Parse`
 
 ## Acceptance Criteria
 
-- [ ] Condition 1
-- [ ] Condition 2
-- [ ] Condition 3
+- [ ] A warehouse staff member can navigate to an admin catalog import page
+- [ ] The page displays a file upload control that accepts `.csv` files and an "Import" button
+- [ ] Uploading a valid CSV file triggers an upsert: new SKUs are inserted, existing SKUs are updated
+- [ ] After a successful import, the page displays a summary: number of rows inserted, number updated, and number skipped
+- [ ] Rows with a missing or blank SKU, Name, or Price are skipped and included in the skipped count
+- [ ] If the uploaded file is not valid CSV or is missing expected columns, an error message is shown and no data is written
+- [ ] Uploading a CSV where every row fails validation shows an appropriate error message (zero records imported)
+- [ ] Uploading the same CSV a second time results in zero insertions and the same number of updates as there are rows (idempotent)

--- a/docs/samples/widgets-import-sample.csv
+++ b/docs/samples/widgets-import-sample.csv
@@ -1,0 +1,13 @@
+SKU,Name,Description,Manufacturer,Weight,Price,Date Available
+WGT-001,Flux Capacitor,Enables time travel when 1.21 gigawatts applied,Outatime Industries,1.21,9999.99,2025-10-26
+WGT-002,Turbo Encabulator,Automatically synchronises cardinal grammeters,Rockwell Automation,4.50,349.00,2025-01-15
+WGT-003,Sonic Screwdriver,Unlocks almost anything except deadlock seals,Gallifrey Tech,0.18,89.95,2024-06-01
+WGT-004,Infinite Improbability Drive,Passes through every conceivable point simultaneously,Sirius Cybernetics,42.00,1.00,2025-03-07
+WGT-005,Dilithium Crystal,Regulates matter/antimatter annihilation reaction,Federation Surplus,0.75,4200.00,2026-01-01
+,Missing SKU Widget,This row should be skipped,Acme Corp,1.00,19.99,2025-01-01
+WGT-007,,Missing Name Widget — skipped,Acme Corp,1.00,19.99,2025-01-01
+WGT-008,Missing Price Widget,This row should be skipped,Acme Corp,1.00,,2025-01-01
+WGT-009,Bad Price Widget,Price is not a decimal — skipped,Acme Corp,1.00,not-a-price,2025-01-01
+WGT-010,Bad Date Widget,Date is not valid — skipped,Acme Corp,1.00,49.99,not-a-date
+WGT-011,Phaser Type II,Adjustable beam from stun to disintegrate,Federation Surplus,0.62,599.00,2025-11-30
+WGT-012,Gravity Boots,Walk on any surface regardless of orientation,Aperture Science,2.30,129.99,2025-08-15

--- a/src/WidgetDepot.ApiService/Features/WidgetEndpoints.cs
+++ b/src/WidgetDepot.ApiService/Features/WidgetEndpoints.cs
@@ -5,4 +5,5 @@ public static class WidgetEndpoints
     private const string Base = "widgets";
 
     public const string Search = $"{Base}/search";
+    public const string Import = $"{Base}/import";
 }

--- a/src/WidgetDepot.ApiService/Features/Widgets/Import/ImportWidgetsCsvEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Widgets/Import/ImportWidgetsCsvEndpoint.cs
@@ -1,0 +1,22 @@
+namespace WidgetDepot.ApiService.Features.Widgets.Import;
+
+public static class ImportWidgetsCsvEndpoint
+{
+    public static IEndpointRouteBuilder MapImportWidgetsCsv(this IEndpointRouteBuilder app)
+    {
+        app.MapPost(WidgetEndpoints.Import, async (IFormFile file, ImportWidgetsCsvHandler handler, CancellationToken cancellationToken) =>
+        {
+            await using var stream = file.OpenReadStream();
+            var result = await handler.HandleAsync(stream, cancellationToken);
+
+            if (result is null)
+                return Results.Problem("The CSV file is missing expected column headers.", statusCode: 400);
+
+            return Results.Ok(result);
+        })
+        .DisableAntiforgery()
+        .WithName("ImportWidgetsCsv");
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Widgets/Import/ImportWidgetsCsvHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Widgets/Import/ImportWidgetsCsvHandler.cs
@@ -1,0 +1,100 @@
+using Microsoft.EntityFrameworkCore;
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Widgets.Import;
+
+public record ImportResult(int Inserted, int Updated, int Skipped);
+
+public class ImportWidgetsCsvHandler(AppDbContext db)
+{
+    private static readonly string[] ExpectedHeaders = ["SKU", "Name", "Description", "Manufacturer", "Weight", "Price", "Date Available"];
+
+    public async Task<ImportResult?> HandleAsync(Stream csvStream, CancellationToken cancellationToken)
+    {
+        using var reader = new StreamReader(csvStream);
+
+        var headerLine = await reader.ReadLineAsync(cancellationToken);
+        if (headerLine is null)
+            return null;
+
+        var headers = headerLine.Split(',');
+        foreach (var expected in ExpectedHeaders)
+        {
+            if (!Array.Exists(headers, h => h.Trim().Equals(expected, StringComparison.OrdinalIgnoreCase)))
+                return null;
+        }
+
+        var rows = new List<(string Sku, string Name, string Description, string Manufacturer, decimal Weight, decimal Price, DateOnly DateAvailable)>();
+
+        int skipped = 0;
+        string? line;
+        while ((line = await reader.ReadLineAsync(cancellationToken)) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            var cols = line.Split(',');
+            if (cols.Length < 7) { skipped++; continue; }
+
+            var sku = cols[0].Trim();
+            var name = cols[1].Trim();
+            var description = cols[2].Trim();
+            var manufacturer = cols[3].Trim();
+            var weightStr = cols[4].Trim();
+            var priceStr = cols[5].Trim();
+            var dateStr = cols[6].Trim();
+
+            if (string.IsNullOrEmpty(sku) || string.IsNullOrEmpty(name) || string.IsNullOrEmpty(priceStr))
+            { skipped++; continue; }
+
+            if (!decimal.TryParse(priceStr, out var price))
+            { skipped++; continue; }
+
+            if (!DateOnly.TryParse(dateStr, out var dateAvailable))
+            { skipped++; continue; }
+
+            decimal.TryParse(weightStr, out var weight);
+
+            rows.Add((sku, name, description, manufacturer, weight, price, dateAvailable));
+        }
+
+        var skus = rows.Select(r => r.Sku).ToList();
+        var existing = await db.Widgets
+            .Where(w => skus.Contains(w.Sku))
+            .ToDictionaryAsync(w => w.Sku, cancellationToken);
+
+        var toAdd = new List<Widget>();
+        int updated = 0;
+
+        foreach (var row in rows)
+        {
+            if (existing.TryGetValue(row.Sku, out var widget))
+            {
+                widget.Name = row.Name;
+                widget.Description = row.Description;
+                widget.Manufacturer = row.Manufacturer;
+                widget.Weight = row.Weight;
+                widget.Price = row.Price;
+                widget.DateAvailable = row.DateAvailable;
+                updated++;
+            }
+            else
+            {
+                toAdd.Add(new Widget
+                {
+                    Sku = row.Sku,
+                    Name = row.Name,
+                    Description = row.Description,
+                    Manufacturer = row.Manufacturer,
+                    Weight = row.Weight,
+                    Price = row.Price,
+                    DateAvailable = row.DateAvailable
+                });
+            }
+        }
+
+        db.Widgets.AddRange(toAdd);
+        await db.SaveChangesAsync(cancellationToken);
+
+        return new ImportResult(toAdd.Count, updated, skipped);
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Widgets/WidgetEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Widgets/WidgetEndpointExtensions.cs
@@ -1,3 +1,4 @@
+using WidgetDepot.ApiService.Features.Widgets.Import;
 using WidgetDepot.ApiService.Features.Widgets.Search;
 
 namespace WidgetDepot.ApiService.Features.Widgets;
@@ -7,7 +8,8 @@ public static class WidgetEndpointExtensions
     public static IEndpointRouteBuilder MapWidgetEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapSearchWidget();
-        
+        app.MapImportWidgetsCsv();
+
         return app;
     }
 }

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Widgets.Import;
 using WidgetDepot.ApiService.Features.Widgets.Search;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -12,6 +13,7 @@ builder.Services.AddProblemDetails();
 
 builder.AddNpgsqlDbContext<AppDbContext>("widgetdepot");
 builder.Services.AddScoped<SearchWidgetsHandler>();
+builder.Services.AddScoped<ImportWidgetsCsvHandler>();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();


### PR DESCRIPTION
## Summary
- Adds `POST /widgets/import` endpoint accepting a multipart `.csv` file upload
- Parses the fixed ERP export format (SKU, Name, Description, Manufacturer, Weight, Price, Date Available)
- Upserts widgets by SKU: new SKUs are inserted, existing ones are updated
- Skips rows with blank SKU, Name, or Price, invalid decimal Price, or invalid DateOnly
- Returns `{ inserted, updated, skipped }` counts on success
- Returns 400 with problem details if expected column headers are missing

## Test plan
- [ ] Upload a valid CSV — verify inserted/updated/skipped counts are correct
- [ ] Upload a CSV with some invalid rows (blank SKU/Name/Price, bad price, bad date) — verify they are skipped
- [ ] Upload a CSV with missing/wrong column headers — verify 400 response with no rows written
- [ ] Upload a CSV with duplicate SKUs against existing data — verify existing rows are updated

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)