### PR TITLE
Tests: Unit tests for ImportWidgetsCsvHandler

### DIFF
--- a/tests/WidgetDepot.Tests/Features/Widgets/Import/ImportWidgetsCsvHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Widgets/Import/ImportWidgetsCsvHandlerTests.cs
@@ -1,0 +1,147 @@
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Widgets.Import;
+
+namespace WidgetDepot.Tests.Features.Widgets.Import;
+
+public class ImportWidgetsCsvHandlerTests
+{
+    private static readonly string ValidHeader = "SKU,Name,Description,Manufacturer,Weight,Price,Date Available";
+
+    private AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static Stream ToCsvStream(string csv)
+        => new MemoryStream(Encoding.UTF8.GetBytes(csv));
+
+    [Fact]
+    public async Task HandleAsync_ValidCsv_InsertsWidgetsAndReturnsInsertedCount()
+    {
+        using var db = CreateDb();
+        var handler = new ImportWidgetsCsvHandler(db);
+
+        var csv = $"""
+            {ValidHeader}
+            SKU001,Widget A,Desc A,MfrA,1.0,9.99,2026-01-01
+            SKU002,Widget B,Desc B,MfrB,2.0,19.99,2026-02-01
+            """;
+
+        var result = await handler.HandleAsync(ToCsvStream(csv), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Inserted);
+        Assert.Equal(0, result.Updated);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(2, await db.Widgets.CountAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task HandleAsync_SameCsvUploadedTwice_UpdatesExistingWidgetsAndReturnsZeroInserted()
+    {
+        using var db = CreateDb();
+        var handler = new ImportWidgetsCsvHandler(db);
+
+        var csv = $"""
+            {ValidHeader}
+            SKU001,Widget A,Desc A,MfrA,1.0,9.99,2026-01-01
+            """;
+
+        await handler.HandleAsync(ToCsvStream(csv), TestContext.Current.CancellationToken);
+
+        var updatedCsv = $"""
+            {ValidHeader}
+            SKU001,Widget A Updated,Desc A Updated,MfrA,1.5,14.99,2026-06-01
+            """;
+
+        var result = await handler.HandleAsync(ToCsvStream(updatedCsv), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(0, result.Inserted);
+        Assert.Equal(1, result.Updated);
+        Assert.Equal(0, result.Skipped);
+
+        var widget = await db.Widgets.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("Widget A Updated", widget.Name);
+        Assert.Equal(14.99m, widget.Price);
+    }
+
+    [Fact]
+    public async Task HandleAsync_RowWithBlankSku_IsSkipped()
+    {
+        using var db = CreateDb();
+        var handler = new ImportWidgetsCsvHandler(db);
+
+        var csv = $"""
+            {ValidHeader}
+            ,Widget A,Desc A,MfrA,1.0,9.99,2026-01-01
+            SKU002,Widget B,Desc B,MfrB,2.0,19.99,2026-02-01
+            """;
+
+        var result = await handler.HandleAsync(ToCsvStream(csv), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Inserted);
+        Assert.Equal(1, result.Skipped);
+    }
+
+    [Fact]
+    public async Task HandleAsync_RowWithBlankName_IsSkipped()
+    {
+        using var db = CreateDb();
+        var handler = new ImportWidgetsCsvHandler(db);
+
+        var csv = $"""
+            {ValidHeader}
+            SKU001,,Desc A,MfrA,1.0,9.99,2026-01-01
+            SKU002,Widget B,Desc B,MfrB,2.0,19.99,2026-02-01
+            """;
+
+        var result = await handler.HandleAsync(ToCsvStream(csv), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Inserted);
+        Assert.Equal(1, result.Skipped);
+    }
+
+    [Fact]
+    public async Task HandleAsync_RowWithBlankPrice_IsSkipped()
+    {
+        using var db = CreateDb();
+        var handler = new ImportWidgetsCsvHandler(db);
+
+        var csv = $"""
+            {ValidHeader}
+            SKU001,Widget A,Desc A,MfrA,1.0,,2026-01-01
+            SKU002,Widget B,Desc B,MfrB,2.0,19.99,2026-02-01
+            """;
+
+        var result = await handler.HandleAsync(ToCsvStream(csv), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Inserted);
+        Assert.Equal(1, result.Skipped);
+    }
+
+    [Fact]
+    public async Task HandleAsync_MissingRequiredColumnHeader_ReturnsNull()
+    {
+        using var db = CreateDb();
+        var handler = new ImportWidgetsCsvHandler(db);
+
+        var csv = """
+            SKU,Name,Description,Manufacturer,Weight,Price
+            SKU001,Widget A,Desc A,MfrA,1.0,9.99
+            """;
+
+        var result = await handler.HandleAsync(ToCsvStream(csv), TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
+        Assert.Equal(0, await db.Widgets.CountAsync(TestContext.Current.CancellationToken));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ImportWidgetsCsvHandlerTests` covering all 6 acceptance criteria
- Uses the `CreateDb()` in-memory EF Core pattern from `SearchWidgetsHandlerTests`
- All tests green, no compiler warnings

## Test plan
- [x] Valid CSV inserts new widgets and returns correct inserted count
- [x] Re-uploading same CSV updates existing widgets and returns 0 inserted
- [x] Row with blank SKU is skipped; skipped count reflects it
- [x] Row with blank Name is skipped
- [x] Row with blank Price is skipped
- [x] CSV with missing required column header returns null (failed result) with no rows written

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)