### PR TITLE
Add registration API endpoint

### DIFF
--- a/src/WidgetDepot.ApiService/EndpointsExtensions.cs
+++ b/src/WidgetDepot.ApiService/EndpointsExtensions.cs
@@ -1,3 +1,4 @@
+using WidgetDepot.ApiService.Features.Accounts;
 using WidgetDepot.ApiService.Features.Widgets;
 
 public static class EndpointsExtensions
@@ -5,6 +6,7 @@ public static class EndpointsExtensions
     public static IEndpointRouteBuilder MapApiEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapWidgetEndpoints();
+        app.MapAccountEndpoints();
 
         return app;
     }

--- a/src/WidgetDepot.ApiService/Features/Accounts/AccountEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Accounts/AccountEndpointExtensions.cs
@@ -1,0 +1,13 @@
+using WidgetDepot.ApiService.Features.Accounts.Register;
+
+namespace WidgetDepot.ApiService.Features.Accounts;
+
+public static class AccountEndpointExtensions
+{
+    public static IEndpointRouteBuilder MapAccountEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapRegister();
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Accounts/Register/RegisterEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Accounts/Register/RegisterEndpoint.cs
@@ -1,0 +1,25 @@
+namespace WidgetDepot.ApiService.Features.Accounts.Register;
+
+public static class RegisterEndpoint
+{
+    public static IEndpointRouteBuilder MapRegister(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/accounts/register", async (RegisterRequest request, RegisterHandler handler, CancellationToken cancellationToken) =>
+        {
+            var result = await handler.HandleAsync(request, cancellationToken);
+
+            return result switch
+            {
+                RegisterError.EmailAlreadyRegistered => Results.Problem(
+                    detail: "The email address is already registered.",
+                    statusCode: 409,
+                    extensions: new Dictionary<string, object?> { ["errorCode"] = "EmailAlreadyRegistered" }),
+                RegisterResponse response => Results.Ok(response),
+                _ => Results.Problem(statusCode: 500)
+            };
+        })
+        .WithName("Register");
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Accounts/Register/RegisterHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Accounts/Register/RegisterHandler.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Accounts.Register;
+
+public record RegisterRequest(string FirstName, string LastName, string Email, string Password);
+
+public record RegisterResponse(int CustomerId);
+
+public abstract record RegisterError
+{
+    public record EmailAlreadyRegistered : RegisterError;
+}
+
+public class RegisterHandler(AppDbContext db)
+{
+    private readonly PasswordHasher<Customer> _passwordHasher = new();
+
+    public async Task<object> HandleAsync(RegisterRequest request, CancellationToken cancellationToken)
+    {
+        var emailExists = await db.Customers
+            .AnyAsync(c => c.Email == request.Email, cancellationToken);
+
+        if (emailExists)
+            return new RegisterError.EmailAlreadyRegistered();
+
+        var customer = new Customer
+        {
+            FirstName = request.FirstName,
+            LastName = request.LastName,
+            Email = request.Email,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        customer.PasswordHash = _passwordHasher.HashPassword(customer, request.Password);
+
+        db.Customers.Add(customer);
+        await db.SaveChangesAsync(cancellationToken);
+
+        return new RegisterResponse(customer.Id);
+    }
+}

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 
 using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Accounts.Register;
 using WidgetDepot.ApiService.Features.Widgets.Import;
 using WidgetDepot.ApiService.Features.Widgets.Search;
 
@@ -15,6 +16,7 @@ builder.Services.AddProblemDetails();
 builder.AddNpgsqlDbContext<AppDbContext>("widgetdepot");
 builder.Services.AddScoped<SearchWidgetsHandler>();
 builder.Services.AddScoped<ImportWidgetsCsvHandler>();
+builder.Services.AddScoped<RegisterHandler>();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();

--- a/tests/WidgetDepot.Tests/Features/Accounts/Register/RegisterHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Accounts/Register/RegisterHandlerTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Accounts.Register;
+
+namespace WidgetDepot.Tests.Features.Accounts.Register;
+
+public class RegisterHandlerTests
+{
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NewEmail_CreatesCustomerAndReturnsResponse()
+    {
+        using var db = CreateDb();
+        var handler = new RegisterHandler(db);
+        var request = new RegisterRequest("Jane", "Doe", "jane@example.com", "P@ssw0rd!");
+
+        var result = await handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<RegisterResponse>();
+        response.CustomerId.ShouldBeGreaterThan(0);
+
+        var customer = await db.Customers.SingleAsync(TestContext.Current.CancellationToken);
+        customer.Email.ShouldBe("jane@example.com");
+        customer.FirstName.ShouldBe("Jane");
+        customer.LastName.ShouldBe("Doe");
+        customer.PasswordHash.ShouldNotBe("P@ssw0rd!");
+        customer.PasswordHash.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_DuplicateEmail_ReturnsEmailAlreadyRegisteredError()
+    {
+        using var db = CreateDb();
+        var handler = new RegisterHandler(db);
+        var request = new RegisterRequest("Jane", "Doe", "jane@example.com", "P@ssw0rd!");
+
+        await handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        var result = await handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RegisterError.EmailAlreadyRegistered>();
+        (await db.Customers.CountAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `POST /accounts/register` endpoint under `Features/Accounts/Register/` following vertical slice architecture
- Handler validates for duplicate email and returns a typed `EmailAlreadyRegistered` error (HTTP 409) rather than a generic 400
- Password is hashed with `PasswordHasher<Customer>` before storage — plain-text password is never persisted
- Endpoint wired into `Program.cs` and `EndpointsExtensions.cs`

## Test plan
- [x] `HandleAsync_NewEmail_CreatesCustomerAndReturnsResponse` — verifies customer is created, password is hashed, and response contains the new ID
- [x] `HandleAsync_DuplicateEmail_ReturnsEmailAlreadyRegisteredError` — verifies duplicate email returns the typed error and no extra row is inserted

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)