### PR TITLE
Add registration Blazor page and login page

### DIFF
--- a/src/WidgetDepot.ApiService/EndpointsExtensions.cs
+++ b/src/WidgetDepot.ApiService/EndpointsExtensions.cs
@@ -1,3 +1,4 @@
+using WidgetDepot.ApiService.Features.Accounts;
 using WidgetDepot.ApiService.Features.Widgets;
 
 public static class EndpointsExtensions
@@ -5,6 +6,7 @@ public static class EndpointsExtensions
     public static IEndpointRouteBuilder MapApiEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapWidgetEndpoints();
+        app.MapAccountEndpoints();
 
         return app;
     }

--- a/src/WidgetDepot.ApiService/Features/Accounts/AccountEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Accounts/AccountEndpointExtensions.cs
@@ -1,0 +1,13 @@
+using WidgetDepot.ApiService.Features.Accounts.Register;
+
+namespace WidgetDepot.ApiService.Features.Accounts;
+
+public static class AccountEndpointExtensions
+{
+    public static IEndpointRouteBuilder MapAccountEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapRegister();
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Accounts/Register/RegisterEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Accounts/Register/RegisterEndpoint.cs
@@ -1,0 +1,25 @@
+namespace WidgetDepot.ApiService.Features.Accounts.Register;
+
+public static class RegisterEndpoint
+{
+    public static IEndpointRouteBuilder MapRegister(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/accounts/register", async (RegisterRequest request, RegisterHandler handler, CancellationToken cancellationToken) =>
+        {
+            var result = await handler.HandleAsync(request, cancellationToken);
+
+            return result switch
+            {
+                RegisterError.EmailAlreadyRegistered => Results.Problem(
+                    detail: "The email address is already registered.",
+                    statusCode: 409,
+                    extensions: new Dictionary<string, object?> { ["errorCode"] = "EmailAlreadyRegistered" }),
+                RegisterResponse response => Results.Ok(response),
+                _ => Results.Problem(statusCode: 500)
+            };
+        })
+        .WithName("Register");
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Accounts/Register/RegisterHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Accounts/Register/RegisterHandler.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Accounts.Register;
+
+public record RegisterRequest(string FirstName, string LastName, string Email, string Password);
+
+public record RegisterResponse(int CustomerId);
+
+public abstract record RegisterError
+{
+    public record EmailAlreadyRegistered : RegisterError;
+}
+
+public class RegisterHandler(AppDbContext db)
+{
+    private readonly PasswordHasher<Customer> _passwordHasher = new();
+
+    public async Task<object> HandleAsync(RegisterRequest request, CancellationToken cancellationToken)
+    {
+        var emailExists = await db.Customers
+            .AnyAsync(c => c.Email == request.Email, cancellationToken);
+
+        if (emailExists)
+            return new RegisterError.EmailAlreadyRegistered();
+
+        var customer = new Customer
+        {
+            FirstName = request.FirstName,
+            LastName = request.LastName,
+            Email = request.Email,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        customer.PasswordHash = _passwordHasher.HashPassword(customer, request.Password);
+
+        db.Customers.Add(customer);
+        await db.SaveChangesAsync(cancellationToken);
+
+        return new RegisterResponse(customer.Id);
+    }
+}

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 
 using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Accounts.Register;
 using WidgetDepot.ApiService.Features.Widgets.Import;
 using WidgetDepot.ApiService.Features.Widgets.Search;
 
@@ -15,6 +16,7 @@ builder.Services.AddProblemDetails();
 builder.AddNpgsqlDbContext<AppDbContext>("widgetdepot");
 builder.Services.AddScoped<SearchWidgetsHandler>();
 builder.Services.AddScoped<ImportWidgetsCsvHandler>();
+builder.Services.AddScoped<RegisterHandler>();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();

--- a/src/WidgetDepot.Web/Features/Accounts/Login/LoginPage.razor
+++ b/src/WidgetDepot.Web/Features/Accounts/Login/LoginPage.razor
@@ -1,0 +1,25 @@
+@page "/accounts/login"
+
+<PageTitle>Sign In</PageTitle>
+
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <h1>Sign In</h1>
+
+        @if (showRegistrationConfirmation)
+        {
+            <div class="alert alert-success">
+                Your account has been created. You can now sign in.
+            </div>
+        }
+
+        <p class="mt-3">
+            Don't have an account? <a href="/accounts/register">Create an account</a>
+        </p>
+    </div>
+</div>
+
+@code {
+    [SupplyParameterFromQuery(Name = "registered")]
+    public bool showRegistrationConfirmation { get; set; }
+}

--- a/src/WidgetDepot.Web/Features/Accounts/Register/RegisterModels.cs
+++ b/src/WidgetDepot.Web/Features/Accounts/Register/RegisterModels.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace WidgetDepot.Web.Features.Accounts.Register;
+
+public class RegisterFormModel
+{
+    [Required(ErrorMessage = "First name is required.")]
+    public string FirstName { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Last name is required.")]
+    public string LastName { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Email address is required.")]
+    [EmailAddress(ErrorMessage = "Email address must be a valid email.")]
+    public string Email { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Password is required.")]
+    [MinLength(8, ErrorMessage = "Password must be at least 8 characters.")]
+    public string Password { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Confirm password is required.")]
+    [Compare(nameof(Password), ErrorMessage = "Passwords do not match.")]
+    public string ConfirmPassword { get; set; } = string.Empty;
+}
+
+public abstract record RegisterResult
+{
+    public record Success : RegisterResult;
+    public record EmailAlreadyRegistered : RegisterResult;
+    public record Failure : RegisterResult;
+}

--- a/src/WidgetDepot.Web/Features/Accounts/Register/RegisterPage.razor
+++ b/src/WidgetDepot.Web/Features/Accounts/Register/RegisterPage.razor
@@ -1,0 +1,104 @@
+@page "/accounts/register"
+@rendermode InteractiveServer
+@inject RegisterService RegisterService
+@inject NavigationManager NavigationManager
+
+<PageTitle>Create Account</PageTitle>
+
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <h1>Create Account</h1>
+
+        @if (errorMessage is not null)
+        {
+            <div class="alert alert-danger">@errorMessage</div>
+        }
+
+        <EditForm Model="form" OnValidSubmit="HandleSubmit">
+            <DataAnnotationsValidator />
+
+            <div class="mb-3">
+                <label class="form-label" for="firstName">First Name</label>
+                <InputText id="firstName" class="form-control" @bind-Value="form.FirstName" />
+                <ValidationMessage For="() => form.FirstName" class="text-danger" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="lastName">Last Name</label>
+                <InputText id="lastName" class="form-control" @bind-Value="form.LastName" />
+                <ValidationMessage For="() => form.LastName" class="text-danger" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="email">Email Address</label>
+                <InputText id="email" type="email" class="form-control" @bind-Value="form.Email" />
+                <ValidationMessage For="() => form.Email" class="text-danger" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="password">Password</label>
+                <InputText id="password" type="password" class="form-control" @bind-Value="form.Password" />
+                <ValidationMessage For="() => form.Password" class="text-danger" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="confirmPassword">Confirm Password</label>
+                <InputText id="confirmPassword" type="password" class="form-control" @bind-Value="form.ConfirmPassword" />
+                <ValidationMessage For="() => form.ConfirmPassword" class="text-danger" />
+            </div>
+
+            <button type="submit" class="btn btn-primary" disabled="@isSubmitting">
+                @if (isSubmitting)
+                {
+                    <span>Creating account...</span>
+                }
+                else
+                {
+                    <span>Create Account</span>
+                }
+            </button>
+        </EditForm>
+
+        <p class="mt-3">
+            Already have an account? <a href="/accounts/login">Sign in</a>
+        </p>
+    </div>
+</div>
+
+@code {
+    private readonly RegisterFormModel form = new();
+    private string? errorMessage;
+    private bool isSubmitting;
+
+    private async Task HandleSubmit()
+    {
+        isSubmitting = true;
+        errorMessage = null;
+
+        try
+        {
+            var result = await RegisterService.RegisterAsync(form);
+
+            switch (result)
+            {
+                case RegisterResult.Success:
+                    NavigationManager.NavigateTo("/accounts/login?registered=true");
+                    break;
+                case RegisterResult.EmailAlreadyRegistered:
+                    errorMessage = "An account with this email address already exists.";
+                    break;
+                default:
+                    errorMessage = "An unexpected error occurred. Please try again.";
+                    break;
+            }
+        }
+        catch (Exception)
+        {
+            errorMessage = "An unexpected error occurred. Please try again.";
+        }
+        finally
+        {
+            isSubmitting = false;
+        }
+    }
+}

--- a/src/WidgetDepot.Web/Features/Accounts/Register/RegisterService.cs
+++ b/src/WidgetDepot.Web/Features/Accounts/Register/RegisterService.cs
@@ -1,0 +1,38 @@
+using System.Net;
+using System.Text.Json;
+
+namespace WidgetDepot.Web.Features.Accounts.Register;
+
+public class RegisterService(HttpClient httpClient)
+{
+    public async Task<RegisterResult> RegisterAsync(RegisterFormModel form, CancellationToken cancellationToken = default)
+    {
+        var request = new
+        {
+            form.FirstName,
+            form.LastName,
+            form.Email,
+            form.Password
+        };
+
+        var response = await httpClient.PostAsJsonAsync("/accounts/register", request, cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+            return new RegisterResult.Success();
+
+        if (response.StatusCode == HttpStatusCode.Conflict)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            using var doc = JsonDocument.Parse(body);
+
+            if (doc.RootElement.TryGetProperty("extensions", out var extensions) &&
+                extensions.TryGetProperty("errorCode", out var errorCode) &&
+                errorCode.GetString() == "EmailAlreadyRegistered")
+            {
+                return new RegisterResult.EmailAlreadyRegistered();
+            }
+        }
+
+        return new RegisterResult.Failure();
+    }
+}

--- a/src/WidgetDepot.Web/Features/Accounts/Register/RegisterService.cs
+++ b/src/WidgetDepot.Web/Features/Accounts/Register/RegisterService.cs
@@ -25,8 +25,7 @@ public class RegisterService(HttpClient httpClient)
             var body = await response.Content.ReadAsStringAsync(cancellationToken);
             using var doc = JsonDocument.Parse(body);
 
-            if (doc.RootElement.TryGetProperty("extensions", out var extensions) &&
-                extensions.TryGetProperty("errorCode", out var errorCode) &&
+            if (doc.RootElement.TryGetProperty("errorCode", out var errorCode) &&
                 errorCode.GetString() == "EmailAlreadyRegistered")
             {
                 return new RegisterResult.EmailAlreadyRegistered();

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -1,4 +1,5 @@
 using WidgetDepot.Web.Components;
+using WidgetDepot.Web.Features.Accounts.Register;
 using WidgetDepot.Web.Features.Admin.CatalogImport;
 using WidgetDepot.Web.Features.Catalog;
 
@@ -15,6 +16,9 @@ builder.Services.AddHttpClient<CatalogService>(client =>
     client.BaseAddress = new Uri("https+http://apiservice"));
 
 builder.Services.AddHttpClient<CatalogImportService>(client =>
+    client.BaseAddress = new Uri("https+http://apiservice"));
+
+builder.Services.AddHttpClient<RegisterService>(client =>
     client.BaseAddress = new Uri("https+http://apiservice"));
 
 var app = builder.Build();

--- a/tests/WidgetDepot.Tests/Features/Accounts/Register/RegisterHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Accounts/Register/RegisterHandlerTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Accounts.Register;
+
+namespace WidgetDepot.Tests.Features.Accounts.Register;
+
+public class RegisterHandlerTests
+{
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NewEmail_CreatesCustomerAndReturnsResponse()
+    {
+        using var db = CreateDb();
+        var handler = new RegisterHandler(db);
+        var request = new RegisterRequest("Jane", "Doe", "jane@example.com", "P@ssw0rd!");
+
+        var result = await handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<RegisterResponse>();
+        response.CustomerId.ShouldBeGreaterThan(0);
+
+        var customer = await db.Customers.SingleAsync(TestContext.Current.CancellationToken);
+        customer.Email.ShouldBe("jane@example.com");
+        customer.FirstName.ShouldBe("Jane");
+        customer.LastName.ShouldBe("Doe");
+        customer.PasswordHash.ShouldNotBe("P@ssw0rd!");
+        customer.PasswordHash.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_DuplicateEmail_ReturnsEmailAlreadyRegisteredError()
+    {
+        using var db = CreateDb();
+        var handler = new RegisterHandler(db);
+        var request = new RegisterRequest("Jane", "Doe", "jane@example.com", "P@ssw0rd!");
+
+        await handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        var result = await handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RegisterError.EmailAlreadyRegistered>();
+        (await db.Customers.CountAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
+    }
+}

--- a/tests/WidgetDepot.Tests/Features/Accounts/Register/RegisterServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Accounts/Register/RegisterServiceTests.cs
@@ -38,9 +38,7 @@ public class RegisterServiceTests
     {
         var body = """
             {
-              "extensions": {
                 "errorCode": "EmailAlreadyRegistered"
-              }
             }
             """;
         var service = CreateService(HttpStatusCode.Conflict, body);
@@ -61,7 +59,7 @@ public class RegisterServiceTests
     [Fact]
     public async Task RegisterAsync_ConflictWithOtherErrorCode_ReturnsFailure()
     {
-        var body = """{"extensions": {"errorCode": "OtherError"}}""";
+        var body = """{"errorCode": "OtherError"}""";
         var service = CreateService(HttpStatusCode.Conflict, body);
         var form = new RegisterFormModel
         {

--- a/tests/WidgetDepot.Tests/Features/Accounts/Register/RegisterServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Accounts/Register/RegisterServiceTests.cs
@@ -1,0 +1,109 @@
+using System.Text;
+
+using Shouldly;
+
+using WidgetDepot.Web.Features.Accounts.Register;
+
+namespace WidgetDepot.Tests.Features.Accounts.Register;
+
+public class RegisterServiceTests
+{
+    private static RegisterService CreateService(HttpStatusCode statusCode, string responseBody)
+    {
+        var handler = new FakeHttpMessageHandler(statusCode, responseBody);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        return new RegisterService(httpClient);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_SuccessResponse_ReturnsSuccess()
+    {
+        var service = CreateService(HttpStatusCode.OK, """{"customerId": 1}""");
+        var form = new RegisterFormModel
+        {
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = "jane@example.com",
+            Password = "P@ssw0rd!",
+            ConfirmPassword = "P@ssw0rd!"
+        };
+
+        var result = await service.RegisterAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RegisterResult.Success>();
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ConflictWithEmailAlreadyRegistered_ReturnsEmailAlreadyRegistered()
+    {
+        var body = """
+            {
+              "extensions": {
+                "errorCode": "EmailAlreadyRegistered"
+              }
+            }
+            """;
+        var service = CreateService(HttpStatusCode.Conflict, body);
+        var form = new RegisterFormModel
+        {
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = "jane@example.com",
+            Password = "P@ssw0rd!",
+            ConfirmPassword = "P@ssw0rd!"
+        };
+
+        var result = await service.RegisterAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RegisterResult.EmailAlreadyRegistered>();
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ConflictWithOtherErrorCode_ReturnsFailure()
+    {
+        var body = """{"extensions": {"errorCode": "OtherError"}}""";
+        var service = CreateService(HttpStatusCode.Conflict, body);
+        var form = new RegisterFormModel
+        {
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = "jane@example.com",
+            Password = "P@ssw0rd!",
+            ConfirmPassword = "P@ssw0rd!"
+        };
+
+        var result = await service.RegisterAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RegisterResult.Failure>();
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ServerError_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError, "{}");
+        var form = new RegisterFormModel
+        {
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = "jane@example.com",
+            Password = "P@ssw0rd!",
+            ConfirmPassword = "P@ssw0rd!"
+        };
+
+        var result = await service.RegisterAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RegisterResult.Failure>();
+    }
+
+    private class FakeHttpMessageHandler(HttpStatusCode statusCode, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/tests/WidgetDepot.Tests/WidgetDepot.Tests.csproj
+++ b/tests/WidgetDepot.Tests/WidgetDepot.Tests.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\WidgetDepot.AppHost\WidgetDepot.AppHost.csproj" />
     <ProjectReference Include="..\..\src\WidgetDepot.ApiService\WidgetDepot.ApiService.csproj" />
+    <ProjectReference Include="..\..\src\WidgetDepot.Web\WidgetDepot.Web.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- New `Register` feature slice at `WidgetDepot.Web/Features/Accounts/Register/` with `RegisterPage.razor`, `RegisterService.cs`, and `RegisterModels.cs`
- New placeholder `LoginPage.razor` at `WidgetDepot.Web/Features/Accounts/Login/` with registration confirmation message and "Create an account" link
- Client-side validation via data annotations: required fields, email format, 8-char password minimum, confirm password match
- Server-side typed error for `EmailAlreadyRegistered` (409 Conflict with `errorCode`)
- On success, redirects to `/accounts/login?registered=true` which shows a confirmation alert
- `RegisterService` registered in `Program.cs`
- `WidgetDepot.Web` added as project reference in test project; 4 unit tests for `RegisterService`

## Test plan

- [x] Build passes with `dotnet build`
- [x] All 18 unit tests pass with `dotnet test`
- [x] Navigate to `/accounts/register` — form displays without auth guard
- [x] Submit empty form — validation messages appear for all fields
- [x] Enter invalid email — validation error shown
- [x] Enter password < 8 chars — validation error shown
- [x] Enter mismatched confirm password — validation error shown
- [x] Register with a duplicate email — server error message displayed
- [x] Successful registration redirects to `/accounts/login` with confirmation alert
- [x] `/accounts/login` shows "Create an account" link to `/accounts/register`

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)