### PR TITLE
Implement POST /accounts/login API endpoint

### DIFF
--- a/src/WidgetDepot.ApiService/Features/Accounts/AccountEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Accounts/AccountEndpointExtensions.cs
@@ -1,3 +1,4 @@
+using WidgetDepot.ApiService.Features.Accounts.Login;
 using WidgetDepot.ApiService.Features.Accounts.Register;
 
 namespace WidgetDepot.ApiService.Features.Accounts;
@@ -7,6 +8,7 @@ public static class AccountEndpointExtensions
     public static IEndpointRouteBuilder MapAccountEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapRegister();
+        app.MapLogin();
 
         return app;
     }

--- a/src/WidgetDepot.ApiService/Features/Accounts/Login/LoginEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Accounts/Login/LoginEndpoint.cs
@@ -1,0 +1,25 @@
+namespace WidgetDepot.ApiService.Features.Accounts.Login;
+
+public static class LoginEndpoint
+{
+    public static IEndpointRouteBuilder MapLogin(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/accounts/login", async (LoginRequest request, LoginHandler handler, CancellationToken cancellationToken) =>
+        {
+            var result = await handler.HandleAsync(request, cancellationToken);
+
+            return result switch
+            {
+                LoginError.InvalidCredentials => Results.Problem(
+                    detail: "Invalid email or password.",
+                    statusCode: 401,
+                    extensions: new Dictionary<string, object?> { ["errorCode"] = "InvalidCredentials" }),
+                LoginResponse response => Results.Ok(response),
+                _ => Results.Problem(statusCode: 500)
+            };
+        })
+        .WithName("Login");
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Accounts/Login/LoginHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Accounts/Login/LoginHandler.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Accounts.Login;
+
+public record LoginRequest(string Email, string Password);
+
+public record LoginResponse(int CustomerId, string Email, string FirstName);
+
+public abstract record LoginError
+{
+    public record InvalidCredentials : LoginError;
+    public record Failure(string Message) : LoginError;
+}
+
+public class LoginHandler(AppDbContext db)
+{
+    private readonly PasswordHasher<Customer> _passwordHasher = new();
+
+    public async Task<object> HandleAsync(LoginRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var customer = await db.Customers
+                .SingleOrDefaultAsync(c => c.Email == request.Email, cancellationToken);
+
+            if (customer is null)
+                return new LoginError.InvalidCredentials();
+
+            var result = _passwordHasher.VerifyHashedPassword(customer, customer.PasswordHash, request.Password);
+
+            if (result == PasswordVerificationResult.Failed)
+                return new LoginError.InvalidCredentials();
+
+            return new LoginResponse(customer.Id, customer.Email, customer.FirstName);
+        }
+        catch (Exception ex)
+        {
+            return new LoginError.Failure(ex.Message);
+        }
+    }
+}

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 
 using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Accounts.Login;
 using WidgetDepot.ApiService.Features.Accounts.Register;
 using WidgetDepot.ApiService.Features.Widgets.Import;
 using WidgetDepot.ApiService.Features.Widgets.Search;
@@ -17,6 +18,7 @@ builder.AddNpgsqlDbContext<AppDbContext>("widgetdepot");
 builder.Services.AddScoped<SearchWidgetsHandler>();
 builder.Services.AddScoped<ImportWidgetsCsvHandler>();
 builder.Services.AddScoped<RegisterHandler>();
+builder.Services.AddScoped<LoginHandler>();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();

--- a/tests/WidgetDepot.Tests/Features/Accounts/Login/LoginHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Accounts/Login/LoginHandlerTests.cs
@@ -74,4 +74,17 @@ public class LoginHandlerTests
 
         result.ShouldBeOfType<LoginError.InvalidCredentials>();
     }
+
+    [Fact]
+    public async Task HandleAsync_DatabaseThrows_ReturnsFailure()
+    {
+        var db = CreateDb();
+        db.Dispose();
+        var handler = new LoginHandler(db);
+        var request = new LoginRequest("jane@example.com", "P@ssw0rd!");
+
+        var result = await handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<LoginError.Failure>();
+    }
 }

--- a/tests/WidgetDepot.Tests/Features/Accounts/Login/LoginHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Accounts/Login/LoginHandlerTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Accounts.Login;
+
+namespace WidgetDepot.Tests.Features.Accounts.Login;
+
+public class LoginHandlerTests
+{
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static async Task<Customer> SeedCustomerAsync(AppDbContext db, string email = "jane@example.com", string password = "P@ssw0rd!")
+    {
+        var hasher = new PasswordHasher<Customer>();
+        var customer = new Customer
+        {
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = email,
+            CreatedAt = DateTime.UtcNow
+        };
+        customer.PasswordHash = hasher.HashPassword(customer, password);
+        db.Customers.Add(customer);
+        await db.SaveChangesAsync();
+        return customer;
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidCredentials_ReturnsLoginResponse()
+    {
+        using var db = CreateDb();
+        await SeedCustomerAsync(db);
+        var handler = new LoginHandler(db);
+        var request = new LoginRequest("jane@example.com", "P@ssw0rd!");
+
+        var result = await handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<LoginResponse>();
+        response.Email.ShouldBe("jane@example.com");
+        response.FirstName.ShouldBe("Jane");
+        response.CustomerId.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task HandleAsync_UnknownEmail_ReturnsInvalidCredentials()
+    {
+        using var db = CreateDb();
+        var handler = new LoginHandler(db);
+        var request = new LoginRequest("unknown@example.com", "P@ssw0rd!");
+
+        var result = await handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<LoginError.InvalidCredentials>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WrongPassword_ReturnsInvalidCredentials()
+    {
+        using var db = CreateDb();
+        await SeedCustomerAsync(db);
+        var handler = new LoginHandler(db);
+        var request = new LoginRequest("jane@example.com", "WrongPassword!");
+
+        var result = await handler.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<LoginError.InvalidCredentials>();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `LoginHandler` with discriminated union result: `LoginResponse` | `LoginError.InvalidCredentials` | `LoginError.Failure`
- Adds `LoginEndpoint` mapping `POST /accounts/login` — returns `200 OK` on success, `401 Unauthorized` on bad credentials
- Registers handler and endpoint in `Program.cs` and `AccountEndpointExtensions.cs`

## Test plan
- [x] Valid credentials return `200 OK` with `customerId`, `email`, `firstName`
- [x] Unknown email returns `401 Unauthorized` with generic message
- [x] Wrong password returns `401 Unauthorized` with generic message
- [x] No credential enumeration — identical response for unknown email vs wrong password

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)