### PR TITLE
Implement login Blazor page

### DIFF
--- a/src/WidgetDepot.Web/Features/Accounts/Login/LoginModels.cs
+++ b/src/WidgetDepot.Web/Features/Accounts/Login/LoginModels.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace WidgetDepot.Web.Features.Accounts.Login;
+
+public class LoginFormModel
+{
+    [Required(ErrorMessage = "Email address is required.")]
+    [EmailAddress(ErrorMessage = "Email address must be a valid email.")]
+    public string Email { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Password is required.")]
+    public string Password { get; set; } = string.Empty;
+}
+
+public abstract record LoginResult
+{
+    public record Success(int CustomerId, string Email, string FirstName) : LoginResult;
+    public record InvalidCredentials : LoginResult;
+    public record Failure : LoginResult;
+}

--- a/src/WidgetDepot.Web/Features/Accounts/Login/LoginModels.cs
+++ b/src/WidgetDepot.Web/Features/Accounts/Login/LoginModels.cs
@@ -12,9 +12,11 @@ public class LoginFormModel
     public string Password { get; set; } = string.Empty;
 }
 
+public record LoginResponse(int CustomerId, string Email, string FirstName);
+
 public abstract record LoginResult
 {
-    public record Success(int CustomerId, string Email, string FirstName) : LoginResult;
+    public record Success(LoginResponse Customer) : LoginResult;
     public record InvalidCredentials : LoginResult;
     public record Failure : LoginResult;
 }

--- a/src/WidgetDepot.Web/Features/Accounts/Login/LoginPage.razor
+++ b/src/WidgetDepot.Web/Features/Accounts/Login/LoginPage.razor
@@ -74,7 +74,7 @@
             switch (result)
             {
                 case LoginResult.Success success:
-                    var url = $"/accounts/do-signin?customerId={success.CustomerId}&email={Uri.EscapeDataString(success.Email)}&firstName={Uri.EscapeDataString(success.FirstName)}";
+                    var url = $"/accounts/do-signin?customerId={success.Customer.CustomerId}&email={Uri.EscapeDataString(success.Customer.Email)}&firstName={Uri.EscapeDataString(success.Customer.FirstName)}";
                     NavigationManager.NavigateTo(url, forceLoad: true);
                     break;
                 case LoginResult.InvalidCredentials:

--- a/src/WidgetDepot.Web/Features/Accounts/Login/LoginPage.razor
+++ b/src/WidgetDepot.Web/Features/Accounts/Login/LoginPage.razor
@@ -1,4 +1,7 @@
 @page "/accounts/login"
+@rendermode InteractiveServer
+@inject LoginService LoginService
+@inject NavigationManager NavigationManager
 
 <PageTitle>Sign In</PageTitle>
 
@@ -13,6 +16,38 @@
             </div>
         }
 
+        @if (errorMessage is not null)
+        {
+            <div class="alert alert-danger">@errorMessage</div>
+        }
+
+        <EditForm Model="form" OnValidSubmit="HandleSubmit">
+            <DataAnnotationsValidator />
+
+            <div class="mb-3">
+                <label class="form-label" for="email">Email Address</label>
+                <InputText id="email" type="email" class="form-control" @bind-Value="form.Email" />
+                <ValidationMessage For="() => form.Email" class="text-danger" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="password">Password</label>
+                <InputText id="password" type="password" class="form-control" @bind-Value="form.Password" />
+                <ValidationMessage For="() => form.Password" class="text-danger" />
+            </div>
+
+            <button type="submit" class="btn btn-primary" disabled="@isSubmitting">
+                @if (isSubmitting)
+                {
+                    <span>Signing in...</span>
+                }
+                else
+                {
+                    <span>Sign In</span>
+                }
+            </button>
+        </EditForm>
+
         <p class="mt-3">
             Don't have an account? <a href="/accounts/register">Create an account</a>
         </p>
@@ -22,4 +57,41 @@
 @code {
     [SupplyParameterFromQuery(Name = "registered")]
     public bool showRegistrationConfirmation { get; set; }
+
+    private readonly LoginFormModel form = new();
+    private string? errorMessage;
+    private bool isSubmitting;
+
+    private async Task HandleSubmit()
+    {
+        isSubmitting = true;
+        errorMessage = null;
+
+        try
+        {
+            var result = await LoginService.LoginAsync(form);
+
+            switch (result)
+            {
+                case LoginResult.Success success:
+                    var url = $"/accounts/do-signin?customerId={success.CustomerId}&email={Uri.EscapeDataString(success.Email)}&firstName={Uri.EscapeDataString(success.FirstName)}";
+                    NavigationManager.NavigateTo(url, forceLoad: true);
+                    break;
+                case LoginResult.InvalidCredentials:
+                    errorMessage = "Invalid email or password";
+                    break;
+                default:
+                    errorMessage = "An unexpected error occurred. Please try again.";
+                    break;
+            }
+        }
+        catch (Exception)
+        {
+            errorMessage = "An unexpected error occurred. Please try again.";
+        }
+        finally
+        {
+            isSubmitting = false;
+        }
+    }
 }

--- a/src/WidgetDepot.Web/Features/Accounts/Login/LoginService.cs
+++ b/src/WidgetDepot.Web/Features/Accounts/Login/LoginService.cs
@@ -1,0 +1,45 @@
+using System.Net;
+using System.Text.Json;
+
+namespace WidgetDepot.Web.Features.Accounts.Login;
+
+public class LoginService(HttpClient httpClient)
+{
+    public async Task<LoginResult> LoginAsync(LoginFormModel form, CancellationToken cancellationToken = default)
+    {
+        var request = new
+        {
+            form.Email,
+            form.Password
+        };
+
+        var response = await httpClient.PostAsJsonAsync("/accounts/login", request, cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+
+            var customerId = root.GetProperty("customerId").GetInt32();
+            var email = root.GetProperty("email").GetString() ?? string.Empty;
+            var firstName = root.GetProperty("firstName").GetString() ?? string.Empty;
+
+            return new LoginResult.Success(customerId, email, firstName);
+        }
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            using var doc = JsonDocument.Parse(body);
+
+            if (doc.RootElement.TryGetProperty("errorCode", out var errorCode) &&
+                errorCode.GetString() == "InvalidCredentials")
+            {
+                return new LoginResult.InvalidCredentials();
+            }
+        }
+
+        return new LoginResult.Failure();
+    }
+}

--- a/src/WidgetDepot.Web/Features/Accounts/Login/LoginService.cs
+++ b/src/WidgetDepot.Web/Features/Accounts/Login/LoginService.cs
@@ -17,15 +17,8 @@ public class LoginService(HttpClient httpClient)
 
         if (response.IsSuccessStatusCode)
         {
-            var body = await response.Content.ReadAsStringAsync(cancellationToken);
-            using var doc = JsonDocument.Parse(body);
-            var root = doc.RootElement;
-
-            var customerId = root.GetProperty("customerId").GetInt32();
-            var email = root.GetProperty("email").GetString() ?? string.Empty;
-            var firstName = root.GetProperty("firstName").GetString() ?? string.Empty;
-
-            return new LoginResult.Success(customerId, email, firstName);
+            var customer = await response.Content.ReadFromJsonAsync<LoginResponse>(cancellationToken);
+            return new LoginResult.Success(customer!);
         }
 
         if (response.StatusCode == HttpStatusCode.Unauthorized)

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -1,6 +1,10 @@
+using System.Security.Claims;
+
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 
 using WidgetDepot.Web.Components;
+using WidgetDepot.Web.Features.Accounts.Login;
 using WidgetDepot.Web.Features.Accounts.Register;
 using WidgetDepot.Web.Features.Admin.CatalogImport;
 using WidgetDepot.Web.Features.Catalog;
@@ -30,6 +34,9 @@ builder.Services.AddHttpClient<CatalogImportService>(client =>
 builder.Services.AddHttpClient<RegisterService>(client =>
     client.BaseAddress = new Uri("https+http://apiservice"));
 
+builder.Services.AddHttpClient<LoginService>(client =>
+    client.BaseAddress = new Uri("https+http://apiservice"));
+
 var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())
@@ -52,5 +59,19 @@ app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 
 app.MapDefaultEndpoints();
+
+app.MapGet("/accounts/do-signin", async (HttpContext context, int customerId, string email, string firstName) =>
+{
+    var claims = new List<Claim>
+    {
+        new(ClaimTypes.NameIdentifier, customerId.ToString()),
+        new(ClaimTypes.Email, email),
+        new(ClaimTypes.Name, firstName)
+    };
+    var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+    var principal = new ClaimsPrincipal(identity);
+    await context.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
+    return Results.Redirect("/");
+});
 
 app.Run();

--- a/tests/WidgetDepot.Tests/Features/Accounts/Login/LoginServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Accounts/Login/LoginServiceTests.cs
@@ -24,9 +24,9 @@ public class LoginServiceTests
         var result = await service.LoginAsync(form, TestContext.Current.CancellationToken);
 
         var success = result.ShouldBeOfType<LoginResult.Success>();
-        success.CustomerId.ShouldBe(42);
-        success.Email.ShouldBe("jane@example.com");
-        success.FirstName.ShouldBe("Jane");
+        success.Customer.CustomerId.ShouldBe(42);
+        success.Customer.Email.ShouldBe("jane@example.com");
+        success.Customer.FirstName.ShouldBe("Jane");
     }
 
     [Fact]

--- a/tests/WidgetDepot.Tests/Features/Accounts/Login/LoginServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Accounts/Login/LoginServiceTests.cs
@@ -1,0 +1,120 @@
+using System.Text;
+
+using Shouldly;
+
+using WidgetDepot.Web.Features.Accounts.Login;
+
+namespace WidgetDepot.Tests.Features.Accounts.Login;
+
+public class LoginServiceTests
+{
+    private static LoginService CreateService(HttpStatusCode statusCode, string responseBody)
+    {
+        var handler = new FakeHttpMessageHandler(statusCode, responseBody);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        return new LoginService(httpClient);
+    }
+
+    [Fact]
+    public async Task LoginAsync_SuccessResponse_ReturnsSuccessWithCustomerInfo()
+    {
+        var service = CreateService(HttpStatusCode.OK, """{"customerId": 42, "email": "jane@example.com", "firstName": "Jane"}""");
+        var form = new LoginFormModel { Email = "jane@example.com", Password = "P@ssw0rd!" };
+
+        var result = await service.LoginAsync(form, TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<LoginResult.Success>();
+        success.CustomerId.ShouldBe(42);
+        success.Email.ShouldBe("jane@example.com");
+        success.FirstName.ShouldBe("Jane");
+    }
+
+    [Fact]
+    public async Task LoginAsync_UnauthorizedWithInvalidCredentials_ReturnsInvalidCredentials()
+    {
+        var body = """{"errorCode": "InvalidCredentials"}""";
+        var service = CreateService(HttpStatusCode.Unauthorized, body);
+        var form = new LoginFormModel { Email = "jane@example.com", Password = "wrong" };
+
+        var result = await service.LoginAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<LoginResult.InvalidCredentials>();
+    }
+
+    [Fact]
+    public async Task LoginAsync_UnauthorizedWithOtherErrorCode_ReturnsFailure()
+    {
+        var body = """{"errorCode": "OtherError"}""";
+        var service = CreateService(HttpStatusCode.Unauthorized, body);
+        var form = new LoginFormModel { Email = "jane@example.com", Password = "wrong" };
+
+        var result = await service.LoginAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<LoginResult.Failure>();
+    }
+
+    [Fact]
+    public async Task LoginAsync_ServerError_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError, "{}");
+        var form = new LoginFormModel { Email = "jane@example.com", Password = "P@ssw0rd!" };
+
+        var result = await service.LoginAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<LoginResult.Failure>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null!)]
+    public void LoginFormModel_EmailRequired_ValidationFails(string? email)
+    {
+        var form = new LoginFormModel { Email = email!, Password = "P@ssw0rd!" };
+
+        var results = ValidateModel(form);
+
+        results.ShouldContain(r => r.MemberNames.Contains(nameof(LoginFormModel.Email)));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null!)]
+    public void LoginFormModel_PasswordRequired_ValidationFails(string? password)
+    {
+        var form = new LoginFormModel { Email = "jane@example.com", Password = password! };
+
+        var results = ValidateModel(form);
+
+        results.ShouldContain(r => r.MemberNames.Contains(nameof(LoginFormModel.Password)));
+    }
+
+    [Fact]
+    public void LoginFormModel_ValidData_PassesValidation()
+    {
+        var form = new LoginFormModel { Email = "jane@example.com", Password = "P@ssw0rd!" };
+
+        var results = ValidateModel(form);
+
+        results.ShouldBeEmpty();
+    }
+
+    private static List<System.ComponentModel.DataAnnotations.ValidationResult> ValidateModel(object model)
+    {
+        var results = new List<System.ComponentModel.DataAnnotations.ValidationResult>();
+        var context = new System.ComponentModel.DataAnnotations.ValidationContext(model);
+        System.ComponentModel.DataAnnotations.Validator.TryValidateObject(model, context, results, validateAllProperties: true);
+        return results;
+    }
+
+    private class FakeHttpMessageHandler(HttpStatusCode statusCode, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `LoginModels.cs` with `LoginFormModel` (email + password with validation) and `LoginResult` discriminated union
- Adds `LoginService.cs` that calls `POST /accounts/login` and maps responses to `LoginResult`
- Completes `LoginPage.razor` with an `EditForm`, validation, disabled-while-submitting button, and registration confirmation message
- Adds `/accounts/do-signin` minimal API endpoint in `Program.cs` that calls `HttpContext.SignInAsync` and redirects to `/`
- Registers `LoginService` with `HttpClient` pointed at `https+http://apiservice`

## Test plan
- [ ] Unit tests for `LoginService` response parsing (success, invalid credentials, other 401, server error)
- [ ] Unit tests for `LoginFormModel` validation (email required, password required, valid data passes)
- [ ] Verify login form shows validation errors before submitting
- [ ] Verify successful login redirects to `/`
- [ ] Verify invalid credentials shows "Invalid email or password"
- [ ] Verify submit button is disabled while submitting
- [ ] Verify `?registered=true` shows the registration confirmation banner

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)