### PR TITLE
Implement customer logout

### DIFF
--- a/src/WidgetDepot.Web/Components/Layout/NavMenu.razor
+++ b/src/WidgetDepot.Web/Components/Layout/NavMenu.razor
@@ -24,5 +24,15 @@
             </NavLink>
         </div>
 
+        <AuthorizeView>
+            <Authorized>
+                <div class="nav-item px-3">
+                    <a class="nav-link" href="/accounts/logout">
+                        <span class="bi bi-box-arrow-right" aria-hidden="true"></span> Sign Out
+                    </a>
+                </div>
+            </Authorized>
+        </AuthorizeView>
+
     </nav>
 </div>

--- a/src/WidgetDepot.Web/Components/_Imports.razor
+++ b/src/WidgetDepot.Web/Components/_Imports.razor
@@ -5,6 +5,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.JSInterop
 @using WidgetDepot.Web
 @using WidgetDepot.Web.Components

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -20,6 +20,7 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
         options.LoginPath = "/accounts/login";
     });
 builder.Services.AddAuthorization();
+builder.Services.AddCascadingAuthenticationState();
 
 // Add services to the container.
 builder.Services.AddRazorComponents()
@@ -71,6 +72,12 @@ app.MapGet("/accounts/do-signin", async (HttpContext context, int customerId, st
     var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
     var principal = new ClaimsPrincipal(identity);
     await context.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
+    return Results.Redirect("/");
+});
+
+app.MapGet("/accounts/logout", async (HttpContext context) =>
+{
+    await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
     return Results.Redirect("/");
 });
 


### PR DESCRIPTION
## Summary
- Adds `GET /accounts/logout` minimal API endpoint that calls `SignOutAsync` and redirects to `/`
- Adds `AddCascadingAuthenticationState()` so `AuthorizeView` works in Blazor components
- Updates `NavMenu.razor` to show a Sign Out link only when the customer is authenticated

## Test plan
- [ ] Log in and confirm Sign Out link appears in the nav
- [ ] Click Sign Out and confirm redirect to home page
- [ ] Confirm auth cookie is cleared (protected routes redirect to login)
- [ ] Confirm Sign Out link is not visible when not authenticated

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)