### PR TITLE
Web: Profile Blazor page (view, edit, cookie refresh)

### DIFF
--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 
 using WidgetDepot.ApiService.Data;
@@ -16,8 +17,23 @@ builder.AddServiceDefaults();
 // Add services to the container.
 builder.Services.AddProblemDetails();
 
+builder.Services.AddDataProtection()
+    .SetApplicationName("WidgetDepot");
+
 builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-    .AddCookie();
+    .AddCookie(options =>
+    {
+        options.Events.OnRedirectToLogin = context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            return Task.CompletedTask;
+        };
+        options.Events.OnRedirectToAccessDenied = context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            return Task.CompletedTask;
+        };
+    });
 builder.Services.AddAuthorization();
 
 builder.AddNpgsqlDbContext<AppDbContext>("widgetdepot");

--- a/src/WidgetDepot.Web/Components/RedirectToLogin.razor
+++ b/src/WidgetDepot.Web/Components/RedirectToLogin.razor
@@ -1,0 +1,9 @@
+@inject NavigationManager NavigationManager
+
+@code {
+    protected override void OnInitialized()
+    {
+        var returnUrl = Uri.EscapeDataString(new Uri(NavigationManager.Uri).PathAndQuery);
+        NavigationManager.NavigateTo($"/accounts/login?returnUrl={returnUrl}", forceLoad: true);
+    }
+}

--- a/src/WidgetDepot.Web/Components/Routes.razor
+++ b/src/WidgetDepot.Web/Components/Routes.razor
@@ -1,6 +1,10 @@
-﻿<Router AppAssembly="typeof(Program).Assembly">
+<Router AppAssembly="typeof(Program).Assembly">
     <Found Context="routeData">
-        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
+        <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)">
+            <NotAuthorized>
+                <RedirectToLogin />
+            </NotAuthorized>
+        </AuthorizeRouteView>
         <FocusOnNavigate RouteData="routeData" Selector="h1" />
     </Found>
 </Router>

--- a/src/WidgetDepot.Web/Features/Accounts/Profile/ProfileModels.cs
+++ b/src/WidgetDepot.Web/Features/Accounts/Profile/ProfileModels.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace WidgetDepot.Web.Features.Accounts.Profile;
+
+public class ProfileFormModel
+{
+    [Required(ErrorMessage = "First name is required.")]
+    public string FirstName { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Last name is required.")]
+    public string LastName { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Email address is required.")]
+    [EmailAddress(ErrorMessage = "Email address must be a valid email.")]
+    public string Email { get; set; } = string.Empty;
+}
+
+public record ProfileResponse(string FirstName, string LastName, string Email);
+
+public abstract record LoadProfileResult
+{
+    public record Success(ProfileResponse Profile) : LoadProfileResult;
+    public record Failure : LoadProfileResult;
+}
+
+public abstract record UpdateProfileResult
+{
+    public record Success(ProfileResponse Profile) : UpdateProfileResult;
+    public record DuplicateEmail : UpdateProfileResult;
+    public record Failure : UpdateProfileResult;
+}

--- a/src/WidgetDepot.Web/Features/Accounts/Profile/ProfilePage.razor
+++ b/src/WidgetDepot.Web/Features/Accounts/Profile/ProfilePage.razor
@@ -1,0 +1,138 @@
+@page "/accounts/profile"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using System.Security.Claims
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
+@inject ProfileService ProfileService
+@inject NavigationManager NavigationManager
+@inject AuthenticationStateProvider AuthenticationStateProvider
+
+<PageTitle>My Profile</PageTitle>
+
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <h1>My Profile</h1>
+
+        @if (showSaveConfirmation)
+        {
+            <div class="alert alert-success">
+                Your profile has been updated.
+            </div>
+        }
+
+        @if (errorMessage is not null)
+        {
+            <div class="alert alert-danger">@errorMessage</div>
+        }
+
+        @if (isLoading)
+        {
+            <p>Loading...</p>
+        }
+        else if (loadFailed)
+        {
+            <div class="alert alert-danger">Unable to load your profile. Please try again later.</div>
+        }
+        else
+        {
+            <EditForm Model="form" OnValidSubmit="HandleSubmit">
+                <DataAnnotationsValidator />
+
+                <div class="mb-3">
+                    <label class="form-label" for="firstName">First Name</label>
+                    <InputText id="firstName" class="form-control" @bind-Value="form.FirstName" />
+                    <ValidationMessage For="() => form.FirstName" class="text-danger" />
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label" for="lastName">Last Name</label>
+                    <InputText id="lastName" class="form-control" @bind-Value="form.LastName" />
+                    <ValidationMessage For="() => form.LastName" class="text-danger" />
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label" for="email">Email Address</label>
+                    <InputText id="email" type="email" class="form-control" @bind-Value="form.Email" />
+                    <ValidationMessage For="() => form.Email" class="text-danger" />
+                </div>
+
+                <button type="submit" class="btn btn-primary" disabled="@isSubmitting">
+                    @if (isSubmitting)
+                    {
+                        <span>Saving...</span>
+                    }
+                    else
+                    {
+                        <span>Save</span>
+                    }
+                </button>
+            </EditForm>
+        }
+    </div>
+</div>
+
+@code {
+    [SupplyParameterFromQuery(Name = "saved")]
+    public bool showSaveConfirmation { get; set; }
+
+    private readonly ProfileFormModel form = new();
+    private string? errorMessage;
+    private bool isLoading = true;
+    private bool loadFailed;
+    private bool isSubmitting;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var result = await ProfileService.LoadAsync();
+
+        switch (result)
+        {
+            case LoadProfileResult.Success success:
+                form.FirstName = success.Profile.FirstName;
+                form.LastName = success.Profile.LastName;
+                form.Email = success.Profile.Email;
+                break;
+            default:
+                loadFailed = true;
+                break;
+        }
+
+        isLoading = false;
+    }
+
+    private async Task HandleSubmit()
+    {
+        isSubmitting = true;
+        errorMessage = null;
+
+        try
+        {
+            var result = await ProfileService.UpdateAsync(form);
+
+            switch (result)
+            {
+                case UpdateProfileResult.Success success:
+                    var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+                    var customerId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
+                    var url = $"/accounts/do-signin?customerId={Uri.EscapeDataString(customerId)}&email={Uri.EscapeDataString(success.Profile.Email)}&firstName={Uri.EscapeDataString(success.Profile.FirstName)}&returnUrl={Uri.EscapeDataString("/accounts/profile?saved=true")}";
+                    NavigationManager.NavigateTo(url, forceLoad: true);
+                    break;
+                case UpdateProfileResult.DuplicateEmail:
+                    errorMessage = "An account with this email address already exists.";
+                    break;
+                default:
+                    errorMessage = "An unexpected error occurred. Please try again.";
+                    break;
+            }
+        }
+        catch (Exception)
+        {
+            errorMessage = "An unexpected error occurred. Please try again.";
+        }
+        finally
+        {
+            isSubmitting = false;
+        }
+    }
+}

--- a/src/WidgetDepot.Web/Features/Accounts/Profile/ProfileService.cs
+++ b/src/WidgetDepot.Web/Features/Accounts/Profile/ProfileService.cs
@@ -1,0 +1,52 @@
+using System.Net;
+using System.Text.Json;
+
+namespace WidgetDepot.Web.Features.Accounts.Profile;
+
+public class ProfileService(HttpClient httpClient)
+{
+    public async Task<LoadProfileResult> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.GetAsync("/accounts/profile", cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var profile = await response.Content.ReadFromJsonAsync<ProfileResponse>(cancellationToken);
+            return new LoadProfileResult.Success(profile!);
+        }
+
+        return new LoadProfileResult.Failure();
+    }
+
+    public async Task<UpdateProfileResult> UpdateAsync(ProfileFormModel form, CancellationToken cancellationToken = default)
+    {
+        var request = new
+        {
+            form.FirstName,
+            form.LastName,
+            form.Email
+        };
+
+        var response = await httpClient.PutAsJsonAsync("/accounts/profile", request, cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var profile = await response.Content.ReadFromJsonAsync<ProfileResponse>(cancellationToken);
+            return new UpdateProfileResult.Success(profile!);
+        }
+
+        if (response.StatusCode == HttpStatusCode.Conflict)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            using var doc = JsonDocument.Parse(body);
+
+            if (doc.RootElement.TryGetProperty("errorCode", out var errorCode) &&
+                errorCode.GetString() == "EmailAlreadyRegistered")
+            {
+                return new UpdateProfileResult.DuplicateEmail();
+            }
+        }
+
+        return new UpdateProfileResult.Failure();
+    }
+}

--- a/src/WidgetDepot.Web/Infrastructure/CookieForwardingHandler.cs
+++ b/src/WidgetDepot.Web/Infrastructure/CookieForwardingHandler.cs
@@ -1,0 +1,19 @@
+using Microsoft.Net.Http.Headers;
+
+namespace WidgetDepot.Web.Infrastructure;
+
+public class CookieForwardingHandler(IHttpContextAccessor httpContextAccessor) : DelegatingHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var cookie = httpContextAccessor.HttpContext?.Request.Headers[HeaderNames.Cookie].ToString();
+
+        if (!string.IsNullOrEmpty(cookie))
+        {
+            request.Headers.Remove(HeaderNames.Cookie);
+            request.Headers.TryAddWithoutValidation(HeaderNames.Cookie, cookie);
+        }
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -5,9 +5,11 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 
 using WidgetDepot.Web.Components;
 using WidgetDepot.Web.Features.Accounts.Login;
+using WidgetDepot.Web.Features.Accounts.Profile;
 using WidgetDepot.Web.Features.Accounts.Register;
 using WidgetDepot.Web.Features.Admin.CatalogImport;
 using WidgetDepot.Web.Features.Catalog;
+using WidgetDepot.Web.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -21,6 +23,8 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
     });
 builder.Services.AddAuthorization();
 builder.Services.AddCascadingAuthenticationState();
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddTransient<CookieForwardingHandler>();
 
 // Add services to the container.
 builder.Services.AddRazorComponents()
@@ -37,6 +41,10 @@ builder.Services.AddHttpClient<RegisterService>(client =>
 
 builder.Services.AddHttpClient<LoginService>(client =>
     client.BaseAddress = new Uri("https+http://apiservice"));
+
+builder.Services.AddHttpClient<ProfileService>(client =>
+    client.BaseAddress = new Uri("https+http://apiservice"))
+    .AddHttpMessageHandler<CookieForwardingHandler>();
 
 var app = builder.Build();
 
@@ -61,7 +69,7 @@ app.MapRazorComponents<App>()
 
 app.MapDefaultEndpoints();
 
-app.MapGet("/accounts/do-signin", async (HttpContext context, int customerId, string email, string firstName) =>
+app.MapGet("/accounts/do-signin", async (HttpContext context, int customerId, string email, string firstName, string? returnUrl) =>
 {
     var claims = new List<Claim>
     {
@@ -72,7 +80,10 @@ app.MapGet("/accounts/do-signin", async (HttpContext context, int customerId, st
     var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
     var principal = new ClaimsPrincipal(identity);
     await context.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
-    return Results.Redirect("/");
+    var target = !string.IsNullOrEmpty(returnUrl) && Uri.IsWellFormedUriString(returnUrl, UriKind.Relative)
+        ? returnUrl
+        : "/";
+    return Results.Redirect(target);
 });
 
 app.MapGet("/accounts/logout", async (HttpContext context) =>

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.DataProtection;
 
 using WidgetDepot.Web.Components;
 using WidgetDepot.Web.Features.Accounts.Login;
@@ -15,6 +16,9 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
+
+builder.Services.AddDataProtection()
+    .SetApplicationName("WidgetDepot");
 
 builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
     .AddCookie(options =>

--- a/tests/WidgetDepot.Tests/Features/Accounts/Profile/ProfileServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Accounts/Profile/ProfileServiceTests.cs
@@ -1,0 +1,166 @@
+using System.Text;
+
+using Shouldly;
+
+using WidgetDepot.Web.Features.Accounts.Profile;
+
+namespace WidgetDepot.Tests.Features.Accounts.Profile;
+
+public class ProfileServiceTests
+{
+    private static ProfileService CreateService(HttpStatusCode statusCode, string responseBody)
+    {
+        var handler = new FakeHttpMessageHandler(statusCode, responseBody);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        return new ProfileService(httpClient);
+    }
+
+    [Fact]
+    public async Task LoadAsync_SuccessResponse_ReturnsSuccessWithProfile()
+    {
+        var service = CreateService(HttpStatusCode.OK, """{"firstName": "Jane", "lastName": "Doe", "email": "jane@example.com"}""");
+
+        var result = await service.LoadAsync(TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<LoadProfileResult.Success>();
+        success.Profile.FirstName.ShouldBe("Jane");
+        success.Profile.LastName.ShouldBe("Doe");
+        success.Profile.Email.ShouldBe("jane@example.com");
+    }
+
+    [Fact]
+    public async Task LoadAsync_NotFound_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.NotFound, "{}");
+
+        var result = await service.LoadAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<LoadProfileResult.Failure>();
+    }
+
+    [Fact]
+    public async Task LoadAsync_ServerError_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError, "{}");
+
+        var result = await service.LoadAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<LoadProfileResult.Failure>();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SuccessResponse_ReturnsSuccessWithProfile()
+    {
+        var service = CreateService(HttpStatusCode.OK, """{"firstName": "Jane", "lastName": "Smith", "email": "jane.smith@example.com"}""");
+        var form = new ProfileFormModel { FirstName = "Jane", LastName = "Smith", Email = "jane.smith@example.com" };
+
+        var result = await service.UpdateAsync(form, TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<UpdateProfileResult.Success>();
+        success.Profile.FirstName.ShouldBe("Jane");
+        success.Profile.LastName.ShouldBe("Smith");
+        success.Profile.Email.ShouldBe("jane.smith@example.com");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ConflictWithEmailAlreadyRegistered_ReturnsDuplicateEmail()
+    {
+        var body = """{"errorCode": "EmailAlreadyRegistered"}""";
+        var service = CreateService(HttpStatusCode.Conflict, body);
+        var form = new ProfileFormModel { FirstName = "Jane", LastName = "Doe", Email = "jane@example.com" };
+
+        var result = await service.UpdateAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<UpdateProfileResult.DuplicateEmail>();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ConflictWithOtherErrorCode_ReturnsFailure()
+    {
+        var body = """{"errorCode": "OtherError"}""";
+        var service = CreateService(HttpStatusCode.Conflict, body);
+        var form = new ProfileFormModel { FirstName = "Jane", LastName = "Doe", Email = "jane@example.com" };
+
+        var result = await service.UpdateAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<UpdateProfileResult.Failure>();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ServerError_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError, "{}");
+        var form = new ProfileFormModel { FirstName = "Jane", LastName = "Doe", Email = "jane@example.com" };
+
+        var result = await service.UpdateAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<UpdateProfileResult.Failure>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null!)]
+    public void ProfileFormModel_FirstNameRequired_ValidationFails(string? firstName)
+    {
+        var form = new ProfileFormModel { FirstName = firstName!, LastName = "Doe", Email = "jane@example.com" };
+
+        var results = ValidateModel(form);
+
+        results.ShouldContain(r => r.MemberNames.Contains(nameof(ProfileFormModel.FirstName)));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null!)]
+    public void ProfileFormModel_LastNameRequired_ValidationFails(string? lastName)
+    {
+        var form = new ProfileFormModel { FirstName = "Jane", LastName = lastName!, Email = "jane@example.com" };
+
+        var results = ValidateModel(form);
+
+        results.ShouldContain(r => r.MemberNames.Contains(nameof(ProfileFormModel.LastName)));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null!)]
+    [InlineData("not-an-email")]
+    public void ProfileFormModel_EmailMustBeValid_ValidationFails(string? email)
+    {
+        var form = new ProfileFormModel { FirstName = "Jane", LastName = "Doe", Email = email! };
+
+        var results = ValidateModel(form);
+
+        results.ShouldContain(r => r.MemberNames.Contains(nameof(ProfileFormModel.Email)));
+    }
+
+    [Fact]
+    public void ProfileFormModel_ValidData_PassesValidation()
+    {
+        var form = new ProfileFormModel { FirstName = "Jane", LastName = "Doe", Email = "jane@example.com" };
+
+        var results = ValidateModel(form);
+
+        results.ShouldBeEmpty();
+    }
+
+    private static List<System.ComponentModel.DataAnnotations.ValidationResult> ValidateModel(object model)
+    {
+        var results = new List<System.ComponentModel.DataAnnotations.ValidationResult>();
+        var context = new System.ComponentModel.DataAnnotations.ValidationContext(model);
+        System.ComponentModel.DataAnnotations.Validator.TryValidateObject(model, context, results, validateAllProperties: true);
+        return results;
+    }
+
+    private class FakeHttpMessageHandler(HttpStatusCode statusCode, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New protected `/accounts/profile` Blazor page (`InteractiveServer`, `[Authorize]`) that loads, edits, and saves the current customer's FirstName, LastName, and Email via `ProfileService`.
- `ProfileService` calls `GET`/`PUT /accounts/profile` and returns discriminated results (`Success`, `DuplicateEmail`, `Failure`); a `CookieForwardingHandler` forwards the auth cookie from Web to ApiService.
- After a successful save, the page redirects through `/accounts/do-signin` (now accepts an optional `returnUrl`) to re-sign the user in with updated claims so the header reflects the new name/email without re-login.
- `Routes.razor` switched to `AuthorizeRouteView` with a `RedirectToLogin` component so unauthenticated visitors to `[Authorize]` pages are sent to the login page.
- 15 new `ProfileServiceTests` cover success/error paths for load and update plus form validation.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — 52 passed, 1 skipped
- [x] Manually verify: unauthenticated visitor to `/accounts/profile` is redirected to login
- [x] Manually verify: authenticated customer can view, edit, and save profile; header updates immediately
- [x] Manually verify: blank fields / invalid email show validation errors; duplicate email shows "already exists" error

Closes #40