### PR TITLE
Web: Password change page

### DIFF
--- a/src/WidgetDepot.Web/Features/Accounts/PasswordChange/PasswordChangeModels.cs
+++ b/src/WidgetDepot.Web/Features/Accounts/PasswordChange/PasswordChangeModels.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace WidgetDepot.Web.Features.Accounts.PasswordChange;
+
+public class PasswordChangeFormModel
+{
+    [Required(ErrorMessage = "Current password is required.")]
+    public string CurrentPassword { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "New password is required.")]
+    [MinLength(8, ErrorMessage = "New password must be at least 8 characters.")]
+    public string NewPassword { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Confirm new password is required.")]
+    [Compare(nameof(NewPassword), ErrorMessage = "New password and confirmation do not match.")]
+    public string ConfirmNewPassword { get; set; } = string.Empty;
+}
+
+public abstract record ChangePasswordResult
+{
+    public record Success : ChangePasswordResult;
+    public record IncorrectPassword : ChangePasswordResult;
+    public record Failure : ChangePasswordResult;
+}

--- a/src/WidgetDepot.Web/Features/Accounts/PasswordChange/PasswordChangePage.razor
+++ b/src/WidgetDepot.Web/Features/Accounts/PasswordChange/PasswordChangePage.razor
@@ -1,0 +1,101 @@
+@page "/accounts/password"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
+@inject PasswordChangeService PasswordChangeService
+
+<PageTitle>Change Password</PageTitle>
+
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <h1>Change Password</h1>
+
+        @if (showSuccessConfirmation)
+        {
+            <div class="alert alert-success">
+                Your password has been updated.
+            </div>
+        }
+
+        @if (errorMessage is not null)
+        {
+            <div class="alert alert-danger">@errorMessage</div>
+        }
+
+        <EditForm Model="form" OnValidSubmit="HandleSubmit">
+            <DataAnnotationsValidator />
+
+            <div class="mb-3">
+                <label class="form-label" for="currentPassword">Current Password</label>
+                <InputText id="currentPassword" type="password" class="form-control" @bind-Value="form.CurrentPassword" />
+                <ValidationMessage For="() => form.CurrentPassword" class="text-danger" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="newPassword">New Password</label>
+                <InputText id="newPassword" type="password" class="form-control" @bind-Value="form.NewPassword" />
+                <ValidationMessage For="() => form.NewPassword" class="text-danger" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="confirmNewPassword">Confirm New Password</label>
+                <InputText id="confirmNewPassword" type="password" class="form-control" @bind-Value="form.ConfirmNewPassword" />
+                <ValidationMessage For="() => form.ConfirmNewPassword" class="text-danger" />
+            </div>
+
+            <button type="submit" class="btn btn-primary" disabled="@isSubmitting">
+                @if (isSubmitting)
+                {
+                    <span>Saving...</span>
+                }
+                else
+                {
+                    <span>Change Password</span>
+                }
+            </button>
+        </EditForm>
+    </div>
+</div>
+
+@code {
+    private readonly PasswordChangeFormModel form = new();
+    private string? errorMessage;
+    private bool isSubmitting;
+    private bool showSuccessConfirmation;
+
+    private async Task HandleSubmit()
+    {
+        isSubmitting = true;
+        errorMessage = null;
+        showSuccessConfirmation = false;
+
+        try
+        {
+            var result = await PasswordChangeService.ChangeAsync(form);
+
+            switch (result)
+            {
+                case ChangePasswordResult.Success:
+                    form.CurrentPassword = string.Empty;
+                    form.NewPassword = string.Empty;
+                    form.ConfirmNewPassword = string.Empty;
+                    showSuccessConfirmation = true;
+                    break;
+                case ChangePasswordResult.IncorrectPassword:
+                    errorMessage = "The current password is incorrect.";
+                    break;
+                default:
+                    errorMessage = "An unexpected error occurred. Please try again.";
+                    break;
+            }
+        }
+        catch (Exception)
+        {
+            errorMessage = "An unexpected error occurred. Please try again.";
+        }
+        finally
+        {
+            isSubmitting = false;
+        }
+    }
+}

--- a/src/WidgetDepot.Web/Features/Accounts/PasswordChange/PasswordChangeService.cs
+++ b/src/WidgetDepot.Web/Features/Accounts/PasswordChange/PasswordChangeService.cs
@@ -1,0 +1,35 @@
+using System.Net;
+using System.Text.Json;
+
+namespace WidgetDepot.Web.Features.Accounts.PasswordChange;
+
+public class PasswordChangeService(HttpClient httpClient)
+{
+    public async Task<ChangePasswordResult> ChangeAsync(PasswordChangeFormModel form, CancellationToken cancellationToken = default)
+    {
+        var request = new
+        {
+            form.CurrentPassword,
+            form.NewPassword
+        };
+
+        var response = await httpClient.PutAsJsonAsync("/accounts/password", request, cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+            return new ChangePasswordResult.Success();
+
+        if (response.StatusCode == HttpStatusCode.Conflict)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            using var doc = JsonDocument.Parse(body);
+
+            if (doc.RootElement.TryGetProperty("errorCode", out var errorCode) &&
+                errorCode.GetString() == "IncorrectPassword")
+            {
+                return new ChangePasswordResult.IncorrectPassword();
+            }
+        }
+
+        return new ChangePasswordResult.Failure();
+    }
+}

--- a/src/WidgetDepot.Web/Features/Accounts/Profile/ProfilePage.razor
+++ b/src/WidgetDepot.Web/Features/Accounts/Profile/ProfilePage.razor
@@ -68,6 +68,10 @@
                     }
                 </button>
             </EditForm>
+
+            <div class="mt-3">
+                <a href="/accounts/password">Change Password</a>
+            </div>
         }
     </div>
 </div>

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.DataProtection;
 
 using WidgetDepot.Web.Components;
 using WidgetDepot.Web.Features.Accounts.Login;
+using WidgetDepot.Web.Features.Accounts.PasswordChange;
 using WidgetDepot.Web.Features.Accounts.Profile;
 using WidgetDepot.Web.Features.Accounts.Register;
 using WidgetDepot.Web.Features.Admin.CatalogImport;
@@ -47,6 +48,10 @@ builder.Services.AddHttpClient<LoginService>(client =>
     client.BaseAddress = new Uri("https+http://apiservice"));
 
 builder.Services.AddHttpClient<ProfileService>(client =>
+    client.BaseAddress = new Uri("https+http://apiservice"))
+    .AddHttpMessageHandler<CookieForwardingHandler>();
+
+builder.Services.AddHttpClient<PasswordChangeService>(client =>
     client.BaseAddress = new Uri("https+http://apiservice"))
     .AddHttpMessageHandler<CookieForwardingHandler>();
 

--- a/tests/WidgetDepot.Tests/Features/Accounts/PasswordChange/PasswordChangeServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Accounts/PasswordChange/PasswordChangeServiceTests.cs
@@ -1,0 +1,182 @@
+using System.Text;
+
+using Shouldly;
+
+using WidgetDepot.Web.Features.Accounts.PasswordChange;
+
+namespace WidgetDepot.Tests.Features.Accounts.PasswordChange;
+
+public class PasswordChangeServiceTests
+{
+    private static PasswordChangeService CreateService(HttpStatusCode statusCode, string responseBody)
+    {
+        var handler = new FakeHttpMessageHandler(statusCode, responseBody);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        return new PasswordChangeService(httpClient);
+    }
+
+    [Fact]
+    public async Task ChangeAsync_SuccessResponse_ReturnsSuccess()
+    {
+        var service = CreateService(HttpStatusCode.NoContent, "");
+        var form = new PasswordChangeFormModel
+        {
+            CurrentPassword = "OldPass1",
+            NewPassword = "NewPass1",
+            ConfirmNewPassword = "NewPass1"
+        };
+
+        var result = await service.ChangeAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<ChangePasswordResult.Success>();
+    }
+
+    [Fact]
+    public async Task ChangeAsync_ConflictWithIncorrectPassword_ReturnsIncorrectPassword()
+    {
+        var body = """{"errorCode": "IncorrectPassword"}""";
+        var service = CreateService(HttpStatusCode.Conflict, body);
+        var form = new PasswordChangeFormModel
+        {
+            CurrentPassword = "WrongPass",
+            NewPassword = "NewPass1",
+            ConfirmNewPassword = "NewPass1"
+        };
+
+        var result = await service.ChangeAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<ChangePasswordResult.IncorrectPassword>();
+    }
+
+    [Fact]
+    public async Task ChangeAsync_ConflictWithOtherErrorCode_ReturnsFailure()
+    {
+        var body = """{"errorCode": "OtherError"}""";
+        var service = CreateService(HttpStatusCode.Conflict, body);
+        var form = new PasswordChangeFormModel
+        {
+            CurrentPassword = "OldPass1",
+            NewPassword = "NewPass1",
+            ConfirmNewPassword = "NewPass1"
+        };
+
+        var result = await service.ChangeAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<ChangePasswordResult.Failure>();
+    }
+
+    [Fact]
+    public async Task ChangeAsync_ServerError_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError, "{}");
+        var form = new PasswordChangeFormModel
+        {
+            CurrentPassword = "OldPass1",
+            NewPassword = "NewPass1",
+            ConfirmNewPassword = "NewPass1"
+        };
+
+        var result = await service.ChangeAsync(form, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<ChangePasswordResult.Failure>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null!)]
+    public void PasswordChangeFormModel_CurrentPasswordRequired_ValidationFails(string? currentPassword)
+    {
+        var form = new PasswordChangeFormModel
+        {
+            CurrentPassword = currentPassword!,
+            NewPassword = "NewPass1",
+            ConfirmNewPassword = "NewPass1"
+        };
+
+        var results = ValidateModel(form);
+
+        results.ShouldContain(r => r.MemberNames.Contains(nameof(PasswordChangeFormModel.CurrentPassword)));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null!)]
+    public void PasswordChangeFormModel_NewPasswordRequired_ValidationFails(string? newPassword)
+    {
+        var form = new PasswordChangeFormModel
+        {
+            CurrentPassword = "OldPass1",
+            NewPassword = newPassword!,
+            ConfirmNewPassword = "NewPass1"
+        };
+
+        var results = ValidateModel(form);
+
+        results.ShouldContain(r => r.MemberNames.Contains(nameof(PasswordChangeFormModel.NewPassword)));
+    }
+
+    [Fact]
+    public void PasswordChangeFormModel_NewPasswordTooShort_ValidationFails()
+    {
+        var form = new PasswordChangeFormModel
+        {
+            CurrentPassword = "OldPass1",
+            NewPassword = "short",
+            ConfirmNewPassword = "short"
+        };
+
+        var results = ValidateModel(form);
+
+        results.ShouldContain(r => r.MemberNames.Contains(nameof(PasswordChangeFormModel.NewPassword)));
+    }
+
+    [Fact]
+    public void PasswordChangeFormModel_ConfirmPasswordMismatch_ValidationFails()
+    {
+        var form = new PasswordChangeFormModel
+        {
+            CurrentPassword = "OldPass1",
+            NewPassword = "NewPass1",
+            ConfirmNewPassword = "Different1"
+        };
+
+        var results = ValidateModel(form);
+
+        results.ShouldContain(r => r.MemberNames.Contains(nameof(PasswordChangeFormModel.ConfirmNewPassword)));
+    }
+
+    [Fact]
+    public void PasswordChangeFormModel_ValidData_PassesValidation()
+    {
+        var form = new PasswordChangeFormModel
+        {
+            CurrentPassword = "OldPass1",
+            NewPassword = "NewPass1",
+            ConfirmNewPassword = "NewPass1"
+        };
+
+        var results = ValidateModel(form);
+
+        results.ShouldBeEmpty();
+    }
+
+    private static List<System.ComponentModel.DataAnnotations.ValidationResult> ValidateModel(object model)
+    {
+        var results = new List<System.ComponentModel.DataAnnotations.ValidationResult>();
+        var context = new System.ComponentModel.DataAnnotations.ValidationContext(model);
+        System.ComponentModel.DataAnnotations.Validator.TryValidateObject(model, context, results, validateAllProperties: true);
+        return results;
+    }
+
+    private class FakeHttpMessageHandler(HttpStatusCode statusCode, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `/accounts/password` Blazor page with Current Password, New Password, and Confirm New Password fields
- Calls `PUT /accounts/password` API endpoint; shows success confirmation or error feedback inline
- Adds "Change Password" link to the Profile page

## Test plan

- [x] Authenticated user navigates to `/accounts/password` and sees the form
- [x] Unauthenticated user navigating to `/accounts/password` is redirected to login
- [x] Submitting with a blank field shows a required-field validation error
- [x] Submitting with mismatched New Password / Confirm New Password shows a validation error
- [x] Submitting with New Password shorter than 8 characters shows a validation error
- [x] Submitting with an incorrect Current Password shows an error message
- [x] Submitting with valid inputs shows a success confirmation and user remains logged in
- [x] Profile page shows "Change Password" link

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)