### PR TITLE
Add milestone-02 story specs and shipping API standard

### DIFF
--- a/docs/milestone-02/01-order-wizard-widget-selection.md
+++ b/docs/milestone-02/01-order-wizard-widget-selection.md
@@ -1,0 +1,56 @@
+# Order wizard: widget selection
+
+## User Story
+
+> As an **authenticated customer**,
+> I need to start a new order by selecting widgets and specifying quantities,
+> in order to begin the process of placing an order.
+
+## Background
+
+Order creation is a multi-step wizard. This story covers step 1: selecting one or more widgets
+from the catalog and entering desired quantities. At the end of this step the order is persisted
+as a draft so that subsequent wizard steps and the save-draft feature (story 04) can build on it.
+
+This story also introduces the core `Order` and `OrderItem` data model.
+
+## Scope
+
+**In scope:**
+- An authenticated-only page at `/orders/new` that begins the wizard
+- A searchable widget list (reuses catalog search) for the customer to pick from
+- Ability to add a widget with a quantity, adjust quantity, and remove a widget from the order
+- A running summary of selected widgets and quantities
+- A "Continue" button that persists the order in `Draft` status and advances to step 2
+- `Order` entity: `Id`, `CustomerId`, `Status` (Draft / Submitted / Cancelled), `CreatedAt`
+- `OrderItem` entity: `Id`, `OrderId`, `WidgetId`, `Quantity`
+- EF Core migration for both entities
+
+**Out of scope:**
+- Address entry (step 2, story 02)
+- Shipping cost estimate (step 3, story 03)
+- Submitting the order (story 05)
+- Editing an existing draft's widget selection after leaving this step (deferred)
+
+## Developer Notes
+
+- New feature slice: `WidgetDepot.Web/Features/Orders/Create/Step1/`
+- New API endpoint: `WidgetDepot.ApiService/Features/Orders/CreateDraft/`
+- New entities in `WidgetDepot.ApiService/Data/`: `Order.cs`, `OrderItem.cs`; add `DbSet<Order>` and `DbSet<OrderItem>` to `AppDbContext`; create a new EF Core migration
+- `WidgetWeight` on `OrderItem` should be captured at order time (denormalized) so that the shipping estimate is stable even if the catalog later changes
+- Order status should be modelled as an enum: `Draft = 0`, `Submitted = 1`, `Cancelled = 2`
+- Patterns to follow: Vertical Slice Architecture; EF Core for data access; Bootstrap 5.3 for layout; no MediatR
+- The widget search on this page can reuse the same API endpoint used by the public catalog
+
+## Acceptance Criteria
+
+- [ ] An unauthenticated visitor attempting to navigate to `/orders/new` is redirected to login
+- [ ] An authenticated customer can navigate to `/orders/new` and sees a widget search interface
+- [ ] Searching for a widget by name or description displays matching results from the catalog
+- [ ] The customer can add a widget to the order by specifying a quantity (minimum 1)
+- [ ] The customer can remove a widget from the order before continuing
+- [ ] The customer can change the quantity of an added widget before continuing
+- [ ] A summary of selected widgets and their quantities is visible at all times during this step
+- [ ] The "Continue" button is disabled (or shows a validation message) if no widgets have been added
+- [ ] Clicking "Continue" with at least one widget persists an `Order` in `Draft` status with the correct `CustomerId` and the corresponding `OrderItem` rows, and advances the wizard to step 2
+- [ ] Unit tests are written where appropriate

--- a/docs/milestone-02/02-order-wizard-addresses.md
+++ b/docs/milestone-02/02-order-wizard-addresses.md
@@ -1,0 +1,49 @@
+# Order wizard: addresses
+
+## User Story
+
+> As an **authenticated customer**,
+> I need to enter shipping and billing addresses for my order,
+> in order to tell WDI where to send my widgets and who to bill.
+
+## Background
+
+This is step 2 of the order creation wizard, reached after the customer has selected widgets
+(story 01). The customer provides a shipping address (where the widgets will be sent) and a
+billing address. Both addresses are stored on the order.
+
+## Scope
+
+**In scope:**
+- Step 2 of the wizard: a form with shipping address fields and billing address fields
+- Address fields for each address: recipient name, street line 1, street line 2 (optional), city, state/province, postal code, country
+- A "Same as shipping address" toggle that copies the shipping address into the billing address fields
+- Client-side and server-side validation of all required fields
+- A "Back" button that returns to step 1 without losing wizard state
+- A "Continue" button that saves the addresses to the draft order and advances to step 3
+- Address data stored on the `Order` entity (inline columns or owned value objects — developer's choice)
+- EF Core migration for the new address columns
+
+**Out of scope:**
+- Address validation against a postal address database or geocoding service
+- Saving a customer's address for re-use on future orders
+- Shipping cost calculation (step 3, story 03)
+
+## Developer Notes
+
+- New feature slice: `WidgetDepot.Web/Features/Orders/Create/Step2/`
+- New API endpoint: `WidgetDepot.ApiService/Features/Orders/SaveAddresses/`
+- Address fields can be stored as owned entity types (`ShippingAddress` / `BillingAddress`) on `Order` using EF Core owned entities, or as prefixed flat columns — whichever is simpler
+- The wizard must carry the `OrderId` (created in step 1) forward to this step (e.g., via route parameter or Blazor cascading state)
+- Patterns to follow: Vertical Slice Architecture; EF Core for data access; Bootstrap 5.3 for layout; no MediatR
+
+## Acceptance Criteria
+
+- [ ] Step 2 is only reachable after step 1 has been completed (order exists in Draft status)
+- [ ] The form displays separate sections for shipping address and billing address
+- [ ] Each address section collects: recipient name, street line 1, street line 2 (optional), city, state/province, postal code, and country
+- [ ] Submitting with any required address field empty shows a validation message and does not proceed
+- [ ] The "Same as shipping address" toggle, when checked, populates the billing address fields with the values from the shipping address fields
+- [ ] Clicking "Back" returns the customer to step 1 with previously selected widgets still present
+- [ ] Clicking "Continue" with valid addresses saves the addresses to the draft order and advances to step 3
+- [ ] Unit tests are written where appropriate

--- a/docs/milestone-02/03-order-wizard-shipping-estimate.md
+++ b/docs/milestone-02/03-order-wizard-shipping-estimate.md
@@ -1,0 +1,53 @@
+# Order wizard: shipping estimate
+
+## User Story
+
+> As an **authenticated customer**,
+> I need to see an estimated shipping cost for my order before saving or submitting it,
+> in order to make an informed decision about whether to proceed.
+
+## Background
+
+This is step 3 of the order creation wizard, reached after the customer has entered addresses
+(story 02). The system calls a third-party shipping API to calculate an estimated cost based on
+the total weight of the ordered widgets and the destination shipping address. The estimate is
+stored on the order.
+
+**Dependency:** The shipping API vendor, endpoint, and credentials are described in [shipping-api](docs/standards/shipping-api.md).
+
+## Scope
+
+**In scope:**
+- Step 3 of the wizard: display of the calculated shipping estimate
+- Calling the third-party shipping API with total widget weight and destination address to obtain the estimate
+- Storing the estimated shipping cost (`ShippingEstimate`, decimal) on the `Order` entity
+- EF Core migration for the new column if not already present
+- A "Back" button that returns to step 2
+- A "Save for later" button that saves the draft order and redirects to the customer's draft orders list (story 04)
+- A "Submit order" button that transitions to order submission (story 05)
+
+**Out of scope:**
+- Actual payment or charge (WDI does not process payments)
+- Re-calculating the estimate if the customer goes back and changes widgets or address (the estimate is fetched once on arrival at this step)
+- Displaying a guaranteed shipping date
+
+## Developer Notes
+
+- New feature slice: `WidgetDepot.Web/Features/Orders/Create/Step3/`
+- New API endpoint: `WidgetDepot.ApiService/Features/Orders/CalculateShipping/`
+- The shipping API client should be implemented behind an interface (e.g., `IShippingApiClient`) so it can be substituted in tests without calling the real API
+- Total weight is calculated as the sum of (`OrderItem.WidgetWeight` × `OrderItem.Quantity`) across all items
+- If the shipping API call fails, show an error message and allow the customer to retry; do not advance the wizard
+- Patterns to follow: Vertical Slice Architecture; EF Core for data access; Bootstrap 5.3 for layout; no MediatR
+
+## Acceptance Criteria
+
+- [ ] Step 3 is only reachable after step 2 has been completed (order has addresses)
+- [ ] On arrival at step 3, the system calls the third-party shipping API and displays the returned estimate
+- [ ] The displayed estimate shows the cost in dollars (or the appropriate currency)
+- [ ] If the API call fails, an error message is shown and a "Retry" option is available; the wizard does not advance
+- [ ] The estimated shipping cost is stored on the order
+- [ ] Clicking "Back" returns the customer to step 2 with previously entered addresses still present
+- [ ] Clicking "Save for later" saves the current draft state and redirects to the draft orders list
+- [ ] Clicking "Submit order" initiates order submission (story 05)
+- [ ] Unit tests are written where appropriate, using a test double for the shipping API client

--- a/docs/milestone-02/04-save-and-resume-draft-orders.md
+++ b/docs/milestone-02/04-save-and-resume-draft-orders.md
@@ -1,0 +1,47 @@
+# Save and resume draft orders
+
+## User Story
+
+> As an **authenticated customer**,
+> I need to view my saved draft orders and return to any of them to complete or delete them,
+> in order to finish placing orders I started but didn't submit right away.
+
+## Background
+
+Orders are persisted as drafts from the moment a customer completes step 1 of the wizard
+(story 01). This story adds the ability for a customer to see all their in-progress drafts
+in one place, navigate back into the wizard to continue a draft, or remove a draft they no
+longer want. Draft orders expire automatically after 30 days (story 06).
+
+## Scope
+
+**In scope:**
+- An authenticated page at `/orders` listing the customer's draft orders
+- Each row displays: order ID, number of widgets, created date, expiry date (created + 30 days)
+- A "Continue" action per row that returns the customer to the correct wizard step (the first step that is incomplete)
+- A "Delete" action per row that removes the draft order after confirmation
+- An empty state message when the customer has no draft orders
+
+**Out of scope:**
+- Listing submitted orders (not part of this milestone)
+- Editing widgets or addresses on a draft that has already progressed past those steps (deferred)
+- Pagination (if needed it can be added later)
+
+## Developer Notes
+
+- New feature slice: `WidgetDepot.Web/Features/Orders/List/`
+- New API endpoint: `WidgetDepot.ApiService/Features/Orders/GetDrafts/` (returns drafts for the authenticated customer)
+- New API endpoint: `WidgetDepot.ApiService/Features/Orders/DeleteDraft/`
+- The "correct wizard step" for resuming is determined by which data is missing: no addresses → step 2; no shipping estimate → step 3; all complete → step 3 (re-review before submitting)
+- Delete should be a soft confirmation (e.g., a modal or inline confirmation prompt) to prevent accidental removal
+- Patterns to follow: Vertical Slice Architecture; EF Core for data access; Bootstrap 5.3 for layout; no MediatR
+
+## Acceptance Criteria
+
+- [ ] An unauthenticated visitor attempting to navigate to `/orders` is redirected to login
+- [ ] An authenticated customer with no draft orders sees an empty state message
+- [ ] An authenticated customer with draft orders sees each draft listed with: order ID, widget count, created date, and expiry date
+- [ ] Clicking "Continue" on a draft navigates the customer back into the wizard at the appropriate incomplete step, with previously entered data still present
+- [ ] Clicking "Delete" on a draft prompts the customer to confirm before deleting
+- [ ] Confirming the delete removes the draft order and it no longer appears in the list
+- [ ] Unit tests are written where appropriate

--- a/docs/milestone-02/05-order-submission.md
+++ b/docs/milestone-02/05-order-submission.md
@@ -1,0 +1,53 @@
+# Order submission
+
+## User Story
+
+> As an **authenticated customer**,
+> I need to submit my completed draft order,
+> in order to send my widget order to WDI for fulfillment.
+
+## Background
+
+Once a customer has completed all wizard steps (widgets, addresses, shipping estimate), they
+can submit the order. Submission changes the order status to `Submitted` and causes the system
+to write an order file to a designated pickup directory. A separate scheduled job (story in
+Milestone 3) transmits those files to the ERP system via FTP.
+
+**Dependency:** The ERP order file format is TBD — it must match the format used by the
+existing website. This story cannot be fully implemented until the format spec is confirmed.
+The story should be implementation-ready in all other respects.
+
+## Scope
+
+**In scope:**
+- A final review screen in the wizard showing a summary of widgets, addresses, and shipping estimate
+- A "Submit" button that triggers order submission
+- On submission: order status is updated to `Submitted`, `SubmittedAt` set to UTC timestamp, an order file is written to the configured pickup directory
+- A confirmation page/message shown to the customer after successful submission, including the order ID
+- Submitted orders are read-only; no further edits or deletion are possible
+
+**Out of scope:**
+- FTP transmission to the ERP system (Milestone 3, story separate)
+- Email confirmation to the customer (not required by the PRD)
+- Payment processing (out of scope for the entire project)
+
+## Developer Notes
+
+- New feature slice: `WidgetDepot.Web/Features/Orders/Submit/`
+- New API endpoint: `WidgetDepot.ApiService/Features/Orders/Submit/`
+- The order file writer should be implemented behind an interface (e.g., `IOrderFileWriter`) so it can be tested without touching the filesystem
+- The pickup directory path should be read from configuration (e.g., `Orders:PickupDirectory`)
+- Order file format must replicate the existing ERP format exactly (spec TBD — treat as a required input before implementation)
+- Only orders with `Draft` status and all required fields populated (widgets, both addresses, shipping estimate) may be submitted; return a typed error otherwise
+- `SubmittedAt` timestamp should be added to the `Order` entity (nullable; set when status transitions to `Submitted`) — add an EF Core migration
+- Patterns to follow: Vertical Slice Architecture; EF Core for data access; Bootstrap 5.3 for layout; no MediatR
+
+## Acceptance Criteria
+
+- [ ] The final review screen displays a summary of all order details: selected widgets with quantities, shipping address, billing address, and estimated shipping cost
+- [ ] A "Back" button on the review screen returns to step 3 without changing the order
+- [ ] Clicking "Submit" submits the order and writes an order file to the configured pickup directory
+- [ ] After successful submission, the customer sees a confirmation message containing the order ID
+- [ ] The submitted order no longer appears in the customer's draft orders list
+- [ ] An order that is missing widgets, addresses, or a shipping estimate cannot be submitted (API returns a descriptive error)
+- [ ] Unit tests are written where appropriate, using a test double for the order file writer

--- a/docs/milestone-02/06-order-auto-expiry.md
+++ b/docs/milestone-02/06-order-auto-expiry.md
@@ -1,0 +1,44 @@
+# 30-day order auto-expiry
+
+## User Story
+
+> As **WDI**,
+> I need draft orders that haven't been submitted within 30 days to be automatically removed,
+> in order to keep the database free of abandoned orders.
+
+## Background
+
+Customers can save draft orders and return to submit them later (story 04). To prevent stale
+drafts from accumulating indefinitely, any draft order that is not submitted within 30 days of
+creation is automatically deleted. The expiry date is surfaced to customers in the draft orders
+list so they know how much time they have.
+
+## Scope
+
+**In scope:**
+- A scheduled background job that runs once per day
+- The job deletes all `Draft` orders where `CreatedAt` is more than 30 days in the past
+- Deleted orders are removed permanently (no soft-delete or archive)
+
+**Out of scope:**
+- Notifying the customer before or after expiry (no email reminder)
+- Configurable expiry window (30 days is fixed per the PRD)
+- A UI for viewing or restoring expired orders
+
+## Developer Notes
+
+- The job should live in `WidgetDepot.ApiService` alongside other background services, or in the appropriate Aspire-hosted project if a worker service already exists
+- Use a standard .NET hosted service (`IHostedService` / `BackgroundService`) or the project's existing scheduling mechanism if one is already in place
+- The deletion query: `DELETE FROM Orders WHERE Status = 'Draft' AND CreatedAt < NOW() - INTERVAL '30 days'`
+- The job should be idempotent — running it multiple times in a day must have no harmful side effects
+- Log the number of orders deleted each time the job runs
+- Patterns to follow: Vertical Slice Architecture; EF Core for data access; no MediatR
+
+## Acceptance Criteria
+
+- [ ] A background job runs once per day (exact schedule configurable, e.g., midnight UTC)
+- [ ] The job deletes all Draft orders with a `CreatedAt` timestamp older than 30 days
+- [ ] Submitted orders are never deleted by this job regardless of age
+- [ ] The job is idempotent: running it multiple times on the same day produces the same result as running it once
+- [ ] The number of orders deleted is logged each time the job executes
+- [ ] Unit tests are written where appropriate

--- a/docs/milestone-02/07-recent-orders.md
+++ b/docs/milestone-02/07-recent-orders.md
@@ -1,0 +1,48 @@
+# Recent submitted orders
+
+## User Story
+
+> As an **authenticated customer**,
+> I need to see my most recently submitted orders in one place,
+> in order to track what I've ordered without having to remember order numbers.
+
+## Background
+
+Once customers begin submitting orders through the new system they will want a quick way to
+review what they've ordered. This story adds a view of the customer's most recent submitted
+orders — up to 10, newest first. Draft orders are not shown here; they remain accessible via
+the draft orders list (story 04).
+
+## Scope
+
+**In scope:**
+- An authenticated page at `/orders/history` showing the customer's submitted orders
+- Up to 10 orders displayed, sorted by submission date descending
+- Each row displays: order ID, submission date, number of widgets, estimated shipping cost
+- Each row links to the order detail view (story 08)
+- An empty state message when the customer has no submitted orders
+
+**Out of scope:**
+- Pagination or "load more" beyond the 10-order cap (deferred)
+- Filtering or sorting controls
+- Draft orders (covered by story 04)
+- Admin order lookup (Milestone 4)
+
+## Developer Notes
+
+- New feature slice: `WidgetDepot.Web/Features/Orders/History/`
+- New API endpoint: `WidgetDepot.ApiService/Features/Orders/GetRecentSubmitted/`
+- Query: submitted orders for the authenticated customer, ordered by `SubmittedAt` descending, limited to 10 rows
+- `SubmittedAt` timestamp should be added to the `Order` entity (nullable; set when status transitions to `Submitted`) — add an EF Core migration if story 05 has not already added this column
+- Patterns to follow: Vertical Slice Architecture; EF Core for data access; Bootstrap 5.3 for layout; no MediatR
+
+## Acceptance Criteria
+
+- [ ] An unauthenticated visitor attempting to navigate to `/orders/history` is redirected to login
+- [ ] A customer with no submitted orders sees an empty state message
+- [ ] A customer with submitted orders sees up to 10 of them, sorted newest first
+- [ ] Each row displays: order ID, submission date, number of widgets, and estimated shipping cost
+- [ ] Each row is clickable and navigates to the order detail view (story 08)
+- [ ] If the customer has more than 10 submitted orders, only the 10 most recent are shown
+- [ ] Draft orders are not shown on this page
+- [ ] Unit tests are written where appropriate

--- a/docs/milestone-02/08-order-detail-lookup.md
+++ b/docs/milestone-02/08-order-detail-lookup.md
@@ -1,0 +1,49 @@
+# Order detail lookup
+
+## User Story
+
+> As an **authenticated customer**,
+> I need to look up one of my orders by order number and see its full details,
+> in order to review or reference a specific order at any time.
+
+## Background
+
+Customers may want to check the details of a specific order — whether it's a draft they're
+still working on or a submitted order they want to review. This story provides a detail page
+reachable by order number. Customers can only view their own orders; entering another
+customer's order number returns a not-found response.
+
+This page is also the destination for the "view detail" links in the recent orders list
+(story 07).
+
+## Scope
+
+**In scope:**
+- An authenticated page at `/orders/{orderNumber}` displaying full order details
+- Details shown: order ID, status, created date, submission date (if submitted), all widgets with quantities and weight, shipping address, billing address, estimated shipping cost
+- A search/lookup form at `/orders/lookup` where the customer can enter an order number and be redirected to the detail page
+- If the order number is not found, or belongs to a different customer, a "not found" message is shown (no distinction between the two cases, to avoid leaking information)
+
+**Out of scope:**
+- Editing or re-submitting an order from this page
+- Admin order lookup (Milestone 4, story 5.7 — staff can look up any order regardless of customer)
+- Linking to or from the draft orders wizard steps
+
+## Developer Notes
+
+- New feature slice: `WidgetDepot.Web/Features/Orders/Detail/`
+- New API endpoint: `WidgetDepot.ApiService/Features/Orders/GetByOrderNumber/`
+- The API endpoint must filter by both order number **and** the authenticated customer's ID — never return an order that belongs to another customer, and return the same 404-equivalent response whether the order doesn't exist or belongs to someone else
+- Route: `/orders/{orderNumber}` — `orderNumber` maps to `Order.Id`
+- The lookup form at `/orders/lookup` can be a simple text input that navigates to `/orders/{enteredNumber}` on submit
+- Patterns to follow: Vertical Slice Architecture; EF Core for data access; Bootstrap 5.3 for layout; no MediatR
+
+## Acceptance Criteria
+
+- [ ] An unauthenticated visitor attempting to navigate to `/orders/{orderNumber}` or `/orders/lookup` is redirected to login
+- [ ] An authenticated customer who enters their own valid order number is shown the full order detail page
+- [ ] The detail page displays: order ID, status, created date, submission date (if submitted), all widgets with quantities, shipping address, billing address, and estimated shipping cost
+- [ ] An authenticated customer who enters an order number belonging to a different customer sees a "not found" message (same as if the order does not exist)
+- [ ] An authenticated customer who enters an order number that does not exist sees a "not found" message
+- [ ] Orders of any status (Draft or Submitted) are accessible via this lookup
+- [ ] Unit tests are written where appropriate

--- a/docs/milestone-02/09-profile-saved-addresses.md
+++ b/docs/milestone-02/09-profile-saved-addresses.md
@@ -1,0 +1,51 @@
+# Profile: saved shipping and billing addresses
+
+## User Story
+
+> As an **authenticated customer**,
+> I need to save a default shipping address and a default billing address on my profile,
+> in order to avoid re-entering the same address details every time I place an order.
+
+## Background
+
+Customers currently have no way to persist address information between orders. This story extends
+the existing customer profile page (Milestone 1, story 05) with shipping and billing address
+sections. Saved addresses are used to pre-populate the order wizard (story 10).
+
+Both address sections are optional — customers are not required to save addresses on their
+profile.
+
+## Scope
+
+**In scope:**
+- Shipping address section and billing address section added to the existing profile edit page (`/accounts/profile`)
+- Address fields for each: recipient name, street line 1, street line 2 (optional), city, state/province, postal code, country
+- A "Same as shipping address" toggle that copies shipping address values into the billing address fields
+- Saving either address section is optional; a customer may save only shipping, only billing, or both
+- Both address sections are saved as part of the existing profile save action (no separate save button per section)
+- `Customer` entity extended with shipping and billing address columns; EF Core migration required
+
+**Out of scope:**
+- Storing multiple saved addresses per customer (one default of each type only)
+- Address book or labelled address management
+- Address validation against a postal database or geocoding service
+
+## Developer Notes
+
+- This story modifies the existing feature slice: `WidgetDepot.Web/Features/Accounts/Profile/`
+- This story modifies the existing API endpoint: `WidgetDepot.ApiService/Features/Accounts/UpdateProfile/`
+- Add shipping and billing address columns to the `Customer` entity using owned value objects or prefixed flat columns (consistent with the approach chosen in story 02)
+- All new address fields are nullable — the customer is not required to provide them
+- The profile GET endpoint should return the saved addresses so the page can pre-populate them on load
+- Patterns to follow: Vertical Slice Architecture; EF Core for data access; Bootstrap 5.3 for layout; no MediatR
+
+## Acceptance Criteria
+
+- [ ] The profile edit page includes a shipping address section and a billing address section
+- [ ] Each section collects: recipient name, street line 1, street line 2 (optional), city, state/province, postal code, and country
+- [ ] The "Same as shipping address" toggle copies the current shipping address values into the billing address fields
+- [ ] All address fields are optional; the profile can be saved without providing any address
+- [ ] When the customer saves the profile, the address values are persisted to the database
+- [ ] On returning to the profile edit page, previously saved address values are pre-filled in the form
+- [ ] If only one address type has been saved, the other section's fields are empty
+- [ ] Unit tests are written where appropriate

--- a/docs/milestone-02/10-order-wizard-address-prefill.md
+++ b/docs/milestone-02/10-order-wizard-address-prefill.md
@@ -1,0 +1,48 @@
+# Order wizard: pre-fill addresses from profile
+
+## User Story
+
+> As an **authenticated customer**,
+> I need the order wizard to pre-fill my shipping and billing addresses from my profile,
+> in order to save time when placing orders without having to retype the same details.
+
+## Background
+
+Once customers can save default addresses on their profile (story 09), those saved values
+should be carried into the order wizard automatically. When the customer reaches step 2
+(address entry), the form is pre-populated with their saved addresses. They can edit the
+values before continuing, so the saved address acts as a convenient starting point rather
+than a hard constraint.
+
+If no address has been saved on the profile, the behaviour is unchanged from story 02 (empty
+form fields).
+
+## Scope
+
+**In scope:**
+- Step 2 of the order wizard pre-fills the shipping and billing address fields with the customer's saved profile addresses when they are available
+- The customer can edit any pre-filled field before continuing; the order stores whatever values are present when "Continue" is clicked (profile defaults are not modified)
+- If only one address type is saved on the profile, only that section is pre-filled; the other remains empty
+- If no addresses are saved on the profile, the form behaves exactly as before (empty)
+
+**Out of scope:**
+- A "reset to profile defaults" button (the customer can navigate back to their profile to update saved addresses)
+- Saving address edits made during the wizard back to the profile
+
+## Developer Notes
+
+- Modifies the existing feature slice: `WidgetDepot.Web/Features/Orders/Create/Step2/`
+- No new API endpoints required — step 2 should call the existing profile GET endpoint (or a dedicated lightweight endpoint) to retrieve the customer's saved addresses and use them to initialise the address form
+- Pre-fill happens client-side at component initialisation; no changes to the address save endpoint
+- The order stores the addresses as entered at "Continue" time, independent of the profile values
+- Patterns to follow: Vertical Slice Architecture; EF Core for data access; Bootstrap 5.3 for layout; no MediatR
+
+## Acceptance Criteria
+
+- [ ] When a customer with saved profile addresses reaches step 2 of the order wizard, the shipping address fields are pre-filled with their saved shipping address
+- [ ] When a customer with saved profile addresses reaches step 2, the billing address fields are pre-filled with their saved billing address
+- [ ] The customer can edit any pre-filled field; the edited values (not the profile defaults) are stored on the order when "Continue" is clicked
+- [ ] Editing the address fields during the wizard does not modify the customer's saved profile addresses
+- [ ] When a customer has no saved profile addresses, step 2 behaves as before (empty address fields)
+- [ ] When only one address type is saved, only that section is pre-filled; the other section remains empty
+- [ ] Unit tests are written where appropriate

--- a/docs/milestone-02/11-order-wizard-update-profile-addresses.md
+++ b/docs/milestone-02/11-order-wizard-update-profile-addresses.md
@@ -1,0 +1,7 @@
+# Order wizard: update profile addresses from order
+
+## User Story
+
+> As an **authenticated customer**,
+> I need the option to save the addresses I enter during checkout back to my profile,
+> in order to keep my saved defaults up to date without visiting the profile page separately.

--- a/docs/standards/shipping-api.md
+++ b/docs/standards/shipping-api.md
@@ -1,0 +1,64 @@
+# Shipping Vendor API
+
+## Overview
+
+- **Vendor:** Acme Shipping Co.
+- **Base URL:** https://api.acmeshipping.com/v1
+- **Protocol:** REST / JSON
+
+---
+
+## Authentication
+
+- **Method:** API Key
+- **Header:** `X-Api-Key: {key}`
+- **Credentials stored in:** environment variable `SHIPPING_API_KEY`
+
+---
+
+## Estimate Shipping Cost
+
+### Request
+
+`POST /estimates`
+
+```json
+{
+  "origin": {
+    "postalCode": "string",
+    "country": "string"
+  },
+  "destination": {
+    "postalCode": "string",
+    "country": "string"
+  },
+  "package": {
+    "weightKg": 0.0
+  }
+}
+```
+
+### Response (200 OK)
+
+```json
+{
+  "estimatedCost": 0.00,
+  "currency": "USD"
+}
+```
+
+### Error Responses
+
+| Status | Meaning |
+|--------|---------|
+| 400 | Bad request — missing or invalid fields |
+| 401 | Authentication failure |
+| 500 | Vendor server error |
+
+Error body:
+```json
+{
+  "error": "string",
+  "message": "string"
+}
+```


### PR DESCRIPTION
## Summary

- Adds 11 user story specification documents for milestone 2, covering the full order wizard flow (widget selection, addresses, shipping estimate), order lifecycle (draft, submission, expiry), order history/lookup, and profile address management
- Adds the shipping API standards document referenced by the shipping estimate story

## Test plan

- [ ] Review each story doc for completeness and accuracy
- [ ] Confirm shipping API standard aligns with the stories that reference it

🤖 Generated with [Claude Code](https://claude.com/claude-code)