### PR TITLE
Add milestone-02 stories for draft order editing

### DIFF
--- a/docs/milestone-02/01-order-wizard-widget-selection.md
+++ b/docs/milestone-02/01-order-wizard-widget-selection.md
@@ -30,7 +30,6 @@ This story also introduces the core `Order` and `OrderItem` data model.
 - Address entry (step 2, story 02)
 - Shipping cost estimate (step 3, story 03)
 - Submitting the order (story 05)
-- Editing an existing draft's widget selection after leaving this step (deferred)
 
 ## Developer Notes
 

--- a/docs/milestone-02/03-order-wizard-shipping-estimate.md
+++ b/docs/milestone-02/03-order-wizard-shipping-estimate.md
@@ -19,7 +19,7 @@ stored on the order.
 
 **In scope:**
 - Step 3 of the wizard: display of the calculated shipping estimate
-- Calling the third-party shipping API with total widget weight and destination address to obtain the estimate
+- Calling the third-party shipping API on every arrival at step 3 to obtain a fresh estimate (including when resuming a draft that already has a stored estimate), overwriting any previously stored value
 - Storing the estimated shipping cost (`ShippingEstimate`, decimal) on the `Order` entity
 - EF Core migration for the new column if not already present
 - A "Back" button that returns to step 2
@@ -28,7 +28,6 @@ stored on the order.
 
 **Out of scope:**
 - Actual payment or charge (WDI does not process payments)
-- Re-calculating the estimate if the customer goes back and changes widgets or address (the estimate is fetched once on arrival at this step)
 - Displaying a guaranteed shipping date
 
 ## Developer Notes
@@ -43,7 +42,7 @@ stored on the order.
 ## Acceptance Criteria
 
 - [ ] Step 3 is only reachable after step 2 has been completed (order has addresses)
-- [ ] On arrival at step 3, the system calls the third-party shipping API and displays the returned estimate
+- [ ] On arrival at step 3, the system **always** calls the third-party shipping API for a fresh estimate and displays the result, overwriting any previously stored estimate
 - [ ] The displayed estimate shows the cost in dollars (or the appropriate currency)
 - [ ] If the API call fails, an error message is shown and a "Retry" option is available; the wizard does not advance
 - [ ] The estimated shipping cost is stored on the order

--- a/docs/milestone-02/04-save-and-resume-draft-orders.md
+++ b/docs/milestone-02/04-save-and-resume-draft-orders.md
@@ -18,13 +18,12 @@ longer want. Draft orders expire automatically after 30 days (story 06).
 **In scope:**
 - An authenticated page at `/orders` listing the customer's draft orders
 - Each row displays: order ID, number of widgets, created date, expiry date (created + 30 days)
-- A "Continue" action per row that returns the customer to the correct wizard step (the first step that is incomplete)
+- A "Resume" action per row that always returns the customer to step 1 of the wizard
 - A "Delete" action per row that removes the draft order after confirmation
 - An empty state message when the customer has no draft orders
 
 **Out of scope:**
 - Listing submitted orders (not part of this milestone)
-- Editing widgets or addresses on a draft that has already progressed past those steps (deferred)
 - Pagination (if needed it can be added later)
 
 ## Developer Notes
@@ -32,7 +31,7 @@ longer want. Draft orders expire automatically after 30 days (story 06).
 - New feature slice: `WidgetDepot.Web/Features/Orders/List/`
 - New API endpoint: `WidgetDepot.ApiService/Features/Orders/GetDrafts/` (returns drafts for the authenticated customer)
 - New API endpoint: `WidgetDepot.ApiService/Features/Orders/DeleteDraft/`
-- The "correct wizard step" for resuming is determined by which data is missing: no addresses → step 2; no shipping estimate → step 3; all complete → step 3 (re-review before submitting)
+- "Resume" always navigates to `/orders/{orderId}/step1`; the customer works through the wizard from step 1 each time they resume a draft
 - Delete should be a soft confirmation (e.g., a modal or inline confirmation prompt) to prevent accidental removal
 - Patterns to follow: Vertical Slice Architecture; EF Core for data access; Bootstrap 5.3 for layout; no MediatR
 
@@ -41,7 +40,7 @@ longer want. Draft orders expire automatically after 30 days (story 06).
 - [ ] An unauthenticated visitor attempting to navigate to `/orders` is redirected to login
 - [ ] An authenticated customer with no draft orders sees an empty state message
 - [ ] An authenticated customer with draft orders sees each draft listed with: order ID, widget count, created date, and expiry date
-- [ ] Clicking "Continue" on a draft navigates the customer back into the wizard at the appropriate incomplete step, with previously entered data still present
+- [ ] Clicking "Resume" on a draft navigates the customer to step 1 of the wizard, with previously selected widgets pre-populated
 - [ ] Clicking "Delete" on a draft prompts the customer to confirm before deleting
 - [ ] Confirming the delete removes the draft order and it no longer appears in the list
 - [ ] Unit tests are written where appropriate

--- a/docs/milestone-02/12-edit-draft-order-widgets.md
+++ b/docs/milestone-02/12-edit-draft-order-widgets.md
@@ -1,0 +1,51 @@
+# Edit draft order: widget selection
+
+## User Story
+
+> As an **authenticated customer**,
+> I need to edit the list of widgets on a draft order I previously started,
+> in order to adjust my selection before continuing to submit the order.
+
+## Background
+
+When a customer resumes a draft order (story 04), they always start at step 1 of the wizard.
+This story covers that entry point: loading the existing widget selection from the draft and
+allowing the customer to make changes before proceeding through the remaining wizard steps.
+Previously saved addresses on the draft are preserved when widgets are updated.
+
+**Dependency:** Requires story 01 (Order entity and `OrderItem` data model), story 04 (draft
+orders list with "Resume" action), and the step 2 page from story 02 to accept an existing
+`orderId`.
+
+## Scope
+
+**In scope:**
+- A version of step 1 that accepts an existing `orderId` and pre-populates the widget list from the saved `OrderItem` rows
+- Entry point: the "Resume" action in the draft orders list (`/orders/{orderId}/step1`)
+- The customer can add widgets, remove widgets, and adjust quantities
+- A "Continue" button that replaces the existing `OrderItem` rows and advances to step 2
+- Previously saved addresses on the draft are preserved (not cleared when widget selection changes)
+
+**Out of scope:**
+- Starting a new order (story 01)
+- Editing addresses or shipping estimate directly (steps 2 and 3)
+
+## Developer Notes
+
+- New feature slice: `WidgetDepot.Web/Features/Orders/Edit/Step1/` (or reuse the story 01 step 1 component with an `orderId` parameter — developer's choice)
+- New API endpoint: `WidgetDepot.ApiService/Features/Orders/UpdateDraftItems/` — deletes existing `OrderItem` rows for the order and inserts the new set; recaptures `WidgetWeight` at update time (same denormalization as story 01)
+- On load, fetch the current `OrderItem` rows for the draft to populate the widget selection UI
+- "Continue" calls `UpdateDraftItems`, then navigates to step 2 with the `orderId`
+- Only orders in `Draft` status owned by the authenticated customer may be edited; return a typed error otherwise
+- Patterns to follow: Vertical Slice Architecture; EF Core for data access; Bootstrap 5.3 for layout; no MediatR
+
+## Acceptance Criteria
+
+- [ ] Step 1 (edit mode) is only reachable for orders in `Draft` status belonging to the authenticated customer; any other attempt returns an appropriate error
+- [ ] Previously selected widgets and quantities are pre-populated when the customer arrives at step 1 via "Resume"
+- [ ] The customer can add a widget with a quantity, adjust quantity, and remove a widget from the order
+- [ ] A summary of selected widgets and their quantities is visible at all times during this step
+- [ ] The "Continue" button is disabled (or shows a validation message) if no widgets are selected
+- [ ] Clicking "Continue" with at least one widget replaces the order's items with the updated selection and advances to step 2
+- [ ] Previously saved addresses on the draft are still present when the customer reaches step 2
+- [ ] Unit tests are written where appropriate

--- a/docs/milestone-02/13-save-draft-from-step-1.md
+++ b/docs/milestone-02/13-save-draft-from-step-1.md
@@ -1,0 +1,56 @@
+# Save draft from Step 1
+
+## User Story
+
+> As an **authenticated customer**,
+> I need to save my widget selection on Step 1 without advancing to the next step,
+> in order to preserve my progress and return to it later.
+
+## Background
+
+Step 1 of both the new-order wizard (story 01, `/orders/new`) and the edit-draft flow
+(story 12, `/orders/{orderId}/step1`) currently only offer a "Continue" button that
+persists the selection and advances to Step 2. This story adds a "Save Draft" button
+alongside "Continue" so customers can save without committing to the next step.
+
+**Dependency:** Requires story 01 (CreateDraft API and new-order Step 1 UI) and
+story 12 (UpdateDraftItems API and edit-mode Step 1 UI).
+
+## Scope
+
+**In scope:**
+- A "Save Draft" button added alongside "Continue" on Step 1 in both flows
+- **New order (`/orders/new`):** clicking "Save Draft" calls the CreateDraft endpoint (story 01),
+  then navigates to `/orders/{orderId}/step1` with a query param (e.g. `?saved=true`) that
+  triggers a "Draft saved" success toast on arrival
+- **Existing draft (`/orders/{orderId}/step1`):** clicking "Save Draft" calls the UpdateDraftItems
+  endpoint (story 12), stays on the same page, and shows a "Draft saved" success toast inline
+- Validation: "Save Draft" is disabled (or shows a validation message) if no widgets are selected —
+  consistent with the "Continue" button behaviour
+- No new API endpoints; both flows reuse endpoints already defined in stories 01 and 12
+
+**Out of scope:**
+- Saving from Step 2 or Step 3 (story 03 already has "Save for later" on Step 3)
+- Any change to the "Continue" button behaviour
+
+## Developer Notes
+
+- Add "Save Draft" button to `WidgetDepot.Web/Features/Orders/Create/Step1/` (story 01 slice)
+- Add "Save Draft" button to `WidgetDepot.Web/Features/Orders/Edit/Step1/` (story 12 slice)
+- Reuse the `CreateDraft` endpoint (story 01) for the new-order save path
+- Reuse the `UpdateDraftItems` endpoint (story 12) for the existing-draft save path
+- Use a `?saved=true` query param (or Blazor navigation state) to trigger the success toast when
+  landing on the edit-mode page after saving a brand-new order
+- Button layout (Bootstrap): `[ Save Draft ]  [ Continue → ]` — Save Draft secondary, Continue primary
+- Patterns to follow: Vertical Slice Architecture; Bootstrap 5.3 for layout; no MediatR
+
+## Acceptance Criteria
+
+- [ ] A "Save Draft" button appears on Step 1 in both the new-order and edit-draft flows
+- [ ] "Save Draft" is disabled (or shows a validation message) when no widgets are selected
+- [ ] Clicking "Save Draft" on a new order (`/orders/new`) persists the order as `Draft` and
+      navigates to `/orders/{orderId}/step1`, where a "Draft saved" success notification is shown
+- [ ] Clicking "Save Draft" on an existing draft (`/orders/{orderId}/step1`) updates the draft's
+      items, keeps the customer on the same page, and shows a "Draft saved" success notification
+- [ ] The "Continue" button on Step 1 continues to work as before in both flows
+- [ ] Unit tests are written where appropriate


### PR DESCRIPTION
## Summary

- Adds **story 12**: edit draft order widget selection — covers the `/orders/{orderId}/step1` edit-mode page and `UpdateDraftItems` API endpoint
- Adds **story 13**: save draft from Step 1 — adds a "Save Draft" button alongside "Continue" on Step 1 for both new-order and edit-draft flows
- Updates **story 01**: removes the deferred note about editing existing draft widget selections, now that story 12 covers it
- Updates **story 03**: clarifies that the shipping estimate is always recalculated fresh on arrival at Step 3 (including when resuming)
- Updates **story 04**: simplifies resume behaviour — "Resume" always returns the customer to Step 1 (removes smart step-detection logic)

## Test plan

- [ ] Review each story spec for completeness and internal consistency
- [ ] Confirm story 13 dependencies on stories 01 and 12 are correctly stated
- [ ] Confirm story 12 is consistent with the updated resume behaviour in story 04

🤖 Generated with [Claude Code](https://claude.com/claude-code)