### PR TITLE
Extract TryGetCustomerId to shared ClaimsPrincipalExtensions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,22 @@ TBD
 
 ---
 
+## Before editing any file
+
+Branch creation is a **precondition**, not a step. Before the first Edit or Write tool call in any task, all of the following must be true:
+
+1. Run `git branch --show-current` to confirm the current branch.
+2. If the current branch is `main`, **stop** and create a new branch first:
+   - `git checkout main`
+   - `git pull`
+   - `git checkout -b <branch-name>`
+3. Only then proceed with edits.
+
+**Never run Edit or Write tools while checked out on `main` or on a stale task branch.** If you notice mid-task that you are on the wrong branch, stop and switch before making further changes.
+
+---
+
+
 ## Local Workflow
 
 > refer to the [github-workflow](./docs/standards/github-workflow.md) for how to interact with the GitHub CLI when asked to work on issues.

--- a/docs/standards/github-workflow.md
+++ b/docs/standards/github-workflow.md
@@ -1,20 +1,5 @@
 # GitHub Workflow
 
-## Before editing any file
-
-Branch creation is a **precondition**, not a step. Before the first Edit or Write tool call in any task, all of the following must be true:
-
-1. Run `git branch --show-current` to confirm the current branch.
-2. If the current branch is `main`, or a leftover branch from a previously-completed issue, **stop** and create a new branch first:
-   - `git checkout main`
-   - `git pull`
-   - `git checkout -b issue-<number>-short-description`
-3. Only then proceed with edits.
-
-**Never run Edit or Write tools while checked out on `main` or on a stale task branch.** If you notice mid-task that you are on the wrong branch, stop and switch before making further changes.
-
----
-
 ## The Local Workflow
 
 - You create an issue in GitHub (via the web UI or `gh issue create`)

--- a/src/WidgetDepot.ApiService/Features/Accounts/PasswordChange/PasswordChangeEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Accounts/PasswordChange/PasswordChangeEndpoint.cs
@@ -8,7 +8,7 @@ public static class PasswordChangeEndpoint
     {
         app.MapPut("/accounts/password", async (ChangePasswordRequest request, ClaimsPrincipal user, PasswordChangeHandler handler, CancellationToken cancellationToken) =>
         {
-            if (!TryGetCustomerId(user, out var customerId))
+            if (!user.TryGetCustomerId(out var customerId))
                 return Results.Unauthorized();
 
             var result = await handler.ChangeAsync(customerId, request, cancellationToken);
@@ -28,11 +28,5 @@ public static class PasswordChangeEndpoint
         .RequireAuthorization();
 
         return app;
-    }
-
-    private static bool TryGetCustomerId(ClaimsPrincipal user, out int customerId)
-    {
-        var claim = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-        return int.TryParse(claim, out customerId);
     }
 }

--- a/src/WidgetDepot.ApiService/Features/Accounts/Profile/ProfileEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Accounts/Profile/ProfileEndpoint.cs
@@ -8,7 +8,7 @@ public static class ProfileEndpoint
     {
         app.MapGet("/accounts/profile", async (ClaimsPrincipal user, ProfileHandler handler, CancellationToken cancellationToken) =>
         {
-            if (!TryGetCustomerId(user, out var customerId))
+            if (!user.TryGetCustomerId(out var customerId))
                 return Results.Unauthorized();
 
             var result = await handler.GetAsync(customerId, cancellationToken);
@@ -25,7 +25,7 @@ public static class ProfileEndpoint
 
         app.MapPut("/accounts/profile", async (UpdateProfileRequest request, ClaimsPrincipal user, ProfileHandler handler, CancellationToken cancellationToken) =>
         {
-            if (!TryGetCustomerId(user, out var customerId))
+            if (!user.TryGetCustomerId(out var customerId))
                 return Results.Unauthorized();
 
             var result = await handler.UpdateAsync(customerId, request, cancellationToken);
@@ -45,11 +45,5 @@ public static class ProfileEndpoint
         .RequireAuthorization();
 
         return app;
-    }
-
-    private static bool TryGetCustomerId(ClaimsPrincipal user, out int customerId)
-    {
-        var claim = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-        return int.TryParse(claim, out customerId);
     }
 }

--- a/src/WidgetDepot.ApiService/Features/Orders/CreateDraft/CreateDraftOrderEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/CreateDraft/CreateDraftOrderEndpoint.cs
@@ -12,7 +12,7 @@ public static class CreateDraftOrderEndpoint
             CreateDraftOrderHandler handler,
             CancellationToken cancellationToken) =>
         {
-            if (!TryGetCustomerId(user, out var customerId))
+            if (!user.TryGetCustomerId(out var customerId))
                 return Results.Unauthorized();
 
             var result = await handler.HandleAsync(customerId, request, cancellationToken);
@@ -28,11 +28,5 @@ public static class CreateDraftOrderEndpoint
         .RequireAuthorization();
 
         return app;
-    }
-
-    private static bool TryGetCustomerId(ClaimsPrincipal user, out int customerId)
-    {
-        var claim = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-        return int.TryParse(claim, out customerId);
     }
 }

--- a/src/WidgetDepot.ApiService/Infrastructure/ClaimsPrincipalExtensions.cs
+++ b/src/WidgetDepot.ApiService/Infrastructure/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,12 @@
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace System.Security.Claims;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+
+public static class ClaimsPrincipalExtensions
+{
+    public static bool TryGetCustomerId(this ClaimsPrincipal user, out int customerId)
+    {
+        var claim = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return int.TryParse(claim, out customerId);
+    }
+}

--- a/tests/WidgetDepot.Tests/Infrastructure/ClaimsPrincipalExtensionsTests.cs
+++ b/tests/WidgetDepot.Tests/Infrastructure/ClaimsPrincipalExtensionsTests.cs
@@ -1,0 +1,49 @@
+using System.Security.Claims;
+
+using Shouldly;
+
+namespace WidgetDepot.Tests.Infrastructure;
+
+public class ClaimsPrincipalExtensionsTests
+{
+    private static ClaimsPrincipal CreateUser(string? nameIdentifier)
+    {
+        var claims = nameIdentifier is null
+            ? []
+            : new[] { new Claim(ClaimTypes.NameIdentifier, nameIdentifier) };
+        return new ClaimsPrincipal(new ClaimsIdentity(claims));
+    }
+
+    [Fact]
+    public void TryGetCustomerId_ValidNameIdentifierClaim_ReturnsTrueAndCorrectId()
+    {
+        var user = CreateUser("42");
+
+        var result = user.TryGetCustomerId(out var customerId);
+
+        result.ShouldBeTrue();
+        customerId.ShouldBe(42);
+    }
+
+    [Fact]
+    public void TryGetCustomerId_MissingClaim_ReturnsFalseAndZero()
+    {
+        var user = CreateUser(null);
+
+        var result = user.TryGetCustomerId(out var customerId);
+
+        result.ShouldBeFalse();
+        customerId.ShouldBe(0);
+    }
+
+    [Fact]
+    public void TryGetCustomerId_NonNumericClaim_ReturnsFalseAndZero()
+    {
+        var user = CreateUser("not-a-number");
+
+        var result = user.TryGetCustomerId(out var customerId);
+
+        result.ShouldBeFalse();
+        customerId.ShouldBe(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Extracted the duplicated `TryGetCustomerId` private method from three endpoint classes into a single `ClaimsPrincipalExtensions` extension method on `ClaimsPrincipal`, placed in the `System.Security.Claims` namespace so callers need no additional `using`
- Added unit tests covering the valid, missing, and non-numeric claim scenarios
- Moved the branch-creation precondition rule from `docs/standards/github-workflow.md` into `CLAUDE.md`

## Test plan

- [x] `dotnet build` passes with no warnings or errors
- [x] `dotnet test` passes — 78 tests pass, 1 skipped (pre-existing)
- [x] New tests in `ClaimsPrincipalExtensionsTests` cover valid ID, missing claim, and non-numeric claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)