### PR TITLE
feat: order wizard step 2 - shipping and billing addresses

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
       "Bash(git branch:*)",
       "Bash(git checkout:*)",
       "Bash(git fetch:*)",
-      "Bash(git remote get-url:*",
+      "Bash(git remote get-url:*)",
       "Bash(find /home/matt/Source/widget-depot/:*)",
       "Bash(gh issue view:*)",
       "Bash(gh pr create:*)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,11 @@ Branch creation is a **precondition**, not a step. Before the first Edit or Writ
 
 ## Local Workflow
 
+### When using the `gh` command line tool
+
+- When specifying `--repo`, always run `gh repo view --json nameWithOwner -q .nameWithOwner` as a separate command first to get the repo name, then pass it as a literal value to the next `gh` command — never use `$(...)` subshell substitution and never parse the repo name from `git remote get-url origin`
+
+
 > refer to the [github-workflow](./docs/standards/github-workflow.md) for how to interact with the GitHub CLI when asked to work on issues.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Branch creation is a **precondition**, not a step. Before the first Edit or Writ
 - When specifying `--repo`, always run `gh repo view --json nameWithOwner -q .nameWithOwner` as a separate command first to get the repo name, then pass it as a literal value to the next `gh` command — never use `$(...)` subshell substitution and never parse the repo name from `git remote get-url origin`
 
 
-> refer to the [github-workflow](./docs/standards/github-workflow.md) for how to interact with the GitHub CLI when asked to work on issues.
+When working on a GitHub issue, you MUST read and follow [github-workflow](./docs/standards/github-workflow.md) before starting.
 
 ---
 

--- a/docs/standards/github-workflow.md
+++ b/docs/standards/github-workflow.md
@@ -6,6 +6,7 @@
 - You tell Claude Code: "Let's work on issue #12"
 - Claude Code checks out the main branch and pulls down the latest commits.
 - Claude Code creates a branch named `issue-<number>-short-description` **before any Edit or Write tool call**.
+- Claude code runs `gh repo view --json nameWithOwner -q .nameWithOwner` to get the repo name, then pass it as a literal value to the next `gh` command — never use `$(...)` subshell substitution and never parse the repo name from `git remote get-url origin`
 - Claude Code reads the issue with `gh issue view 12`, understands the task, and starts working
 - As work progresses, it (or you) can post progress updates as issue comments with `gh issue comment`
 - When done, Claude Code pushes the commits to the remote repo and then Claude Code opens a PR linked to the issue with `gh pr create`
@@ -40,6 +41,7 @@ git fetch --prune
 ## GitHub CLI Usage
 
 - Always use the GitHub CLI (`gh`) to interact with GitHub — never GitHub Actions
+- When specifying `--repo`, always run `gh repo view --json nameWithOwner -q .nameWithOwner` as a separate command first to get the repo name, then pass it as a literal value to the next `gh` command — never use `$(...)` subshell substitution and never parse the repo name from `git remote get-url origin`
 - When starting work on an issue, run `gh issue view <number>` to read the full details before doing anything
 - Create a branch named `issue-<number>-short-description` **before any Edit or Write tool call**
 - Post a comment on the issue when starting work: "Starting work on this issue"
@@ -47,7 +49,6 @@ git fetch --prune
 - Check off acceptance criteria checkboxes in the issue as each one is completed using `gh issue edit`
 - When work is complete, push the commits to the remote repo and open a PR using `gh pr create` with "Closes #<number>" in the body
 - Never commit directly to main, and never edit files while checked out on `main`
-- When specifying `--repo`, always run `gh repo view --json nameWithOwner -q .nameWithOwner` as a separate command first to get the repo name, then pass it as a literal value to the next `gh` command — never use `$(...)` subshell substitution and never parse the repo name from `git remote get-url origin`
 
 ---
 

--- a/src/WidgetDepot.ApiService/Features/Orders/GetDraftOrder/GetDraftOrderEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/GetDraftOrder/GetDraftOrderEndpoint.cs
@@ -1,0 +1,33 @@
+using System.Security.Claims;
+
+namespace WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
+
+public static class GetDraftOrderEndpoint
+{
+    public static IEndpointRouteBuilder MapGetDraftOrder(this IEndpointRouteBuilder app)
+    {
+        app.MapGet(OrderEndpoints.GetDraftOrder, async (
+            int orderId,
+            ClaimsPrincipal user,
+            GetDraftOrderHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            if (!user.TryGetCustomerId(out var customerId))
+                return Results.Unauthorized();
+
+            var result = await handler.HandleAsync(orderId, customerId, cancellationToken);
+
+            return result switch
+            {
+                GetDraftOrderError.OrderNotFound => Results.NotFound(),
+                GetDraftOrderError.Forbidden => Results.Forbid(),
+                GetDraftOrderResponse response => Results.Ok(response),
+                _ => Results.Problem(statusCode: 500)
+            };
+        })
+        .WithName("GetDraftOrder")
+        .RequireAuthorization();
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/GetDraftOrder/GetDraftOrderHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/GetDraftOrder/GetDraftOrderHandler.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
+
+public record GetDraftOrderItemResponse(int WidgetId, int Quantity);
+
+public record GetDraftOrderAddressResponse(
+    string RecipientName,
+    string StreetLine1,
+    string? StreetLine2,
+    string City,
+    string State,
+    string ZipCode);
+
+public record GetDraftOrderResponse(
+    int Id,
+    string Status,
+    IReadOnlyList<GetDraftOrderItemResponse> Items,
+    GetDraftOrderAddressResponse? ShippingAddress,
+    GetDraftOrderAddressResponse? BillingAddress);
+
+public abstract record GetDraftOrderError
+{
+    public record OrderNotFound : GetDraftOrderError;
+    public record Forbidden : GetDraftOrderError;
+}
+
+public class GetDraftOrderHandler(AppDbContext db)
+{
+    public async Task<object> HandleAsync(int orderId, int customerId, CancellationToken cancellationToken)
+    {
+        var order = await db.Orders
+            .Include(o => o.Items)
+            .FirstOrDefaultAsync(o => o.Id == orderId, cancellationToken);
+
+        if (order is null)
+            return new GetDraftOrderError.OrderNotFound();
+
+        if (order.CustomerId != customerId)
+            return new GetDraftOrderError.Forbidden();
+
+        return new GetDraftOrderResponse(
+            order.Id,
+            order.Status.ToString(),
+            [.. order.Items.Select(i => new GetDraftOrderItemResponse(i.WidgetId, i.Quantity))],
+            MapAddress(order.ShippingAddress),
+            MapAddress(order.BillingAddress));
+    }
+
+    private static GetDraftOrderAddressResponse? MapAddress(Address? address) =>
+        address is null ? null : new GetDraftOrderAddressResponse(
+            address.RecipientName,
+            address.StreetLine1,
+            address.StreetLine2,
+            address.City,
+            address.State,
+            address.ZipCode);
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
@@ -1,4 +1,5 @@
 using WidgetDepot.ApiService.Features.Orders.CreateDraft;
+using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
 
 namespace WidgetDepot.ApiService.Features.Orders;
@@ -8,6 +9,7 @@ public static class OrderEndpointExtensions
     public static IEndpointRouteBuilder MapOrderEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapCreateDraftOrder();
+        app.MapGetDraftOrder();
         app.MapSaveAddresses();
 
         return app;

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
@@ -6,4 +6,5 @@ public static class OrderEndpoints
 
     public const string CreateDraft = $"{Base}/draft";
     public const string SaveAddresses = $"{Base}/{{orderId}}/addresses";
+    public const string GetDraftOrder = $"{Base}/{{orderId}}/draft";
 }

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -8,6 +8,7 @@ using WidgetDepot.ApiService.Features.Accounts.PasswordChange;
 using WidgetDepot.ApiService.Features.Accounts.Profile;
 using WidgetDepot.ApiService.Features.Accounts.Register;
 using WidgetDepot.ApiService.Features.Orders.CreateDraft;
+using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
 using WidgetDepot.ApiService.Features.Widgets.Import;
 using WidgetDepot.ApiService.Features.Widgets.Search;
@@ -41,6 +42,7 @@ builder.Services.AddAuthorization();
 
 builder.AddNpgsqlDbContext<AppDbContext>("widgetdepot");
 builder.Services.AddScoped<CreateDraftOrderHandler>();
+builder.Services.AddScoped<GetDraftOrderHandler>();
 builder.Services.AddScoped<SaveAddressesHandler>();
 builder.Services.AddScoped<SearchWidgetsHandler>();
 builder.Services.AddScoped<ImportWidgetsCsvHandler>();

--- a/src/WidgetDepot.Web/Features/Orders/Create/OrderWizardState.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/OrderWizardState.cs
@@ -1,0 +1,11 @@
+using WidgetDepot.Web.Features.Orders.Create.Step1;
+using WidgetDepot.Web.Features.Orders.Create.Step2;
+
+namespace WidgetDepot.Web.Features.Orders.Create;
+
+public class OrderWizardState
+{
+    public int OrderId { get; set; }
+    public List<OrderItemModel> SelectedItems { get; set; } = [];
+    public Step2FormModel AddressData { get; set; } = new();
+}

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Page.razor
@@ -2,9 +2,11 @@
 @rendermode InteractiveServer
 @attribute [Authorize]
 @using Microsoft.AspNetCore.Authorization
+@using WidgetDepot.Web.Features.Orders.Create
 @using WidgetDepot.Web.Features.Orders.Create.Step1
 @inject Step1Service Step1Service
 @inject NavigationManager NavigationManager
+@inject OrderWizardState WizardState
 
 <PageTitle>New Order</PageTitle>
 
@@ -131,6 +133,14 @@
     private string? errorMessage;
     private bool isSubmitting;
 
+    protected override void OnInitialized()
+    {
+        if (WizardState.SelectedItems.Count > 0)
+        {
+            selectedItems.AddRange(WizardState.SelectedItems);
+        }
+    }
+
     private async Task ExecuteSearch()
     {
         if (string.IsNullOrWhiteSpace(searchTerm))
@@ -192,6 +202,8 @@
             switch (result)
             {
                 case CreateDraftResult.Success success:
+                    WizardState.OrderId = success.OrderId;
+                    WizardState.SelectedItems = new List<OrderItemModel>(selectedItems);
                     NavigationManager.NavigateTo($"/orders/{success.OrderId}/address");
                     break;
                 default:

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Models.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Models.cs
@@ -107,6 +107,23 @@ public static class UsStates
     ];
 }
 
+public record GetDraftOrderItemResponse(int WidgetId, int Quantity);
+
+public record GetDraftOrderAddressResponse(
+    string RecipientName,
+    string StreetLine1,
+    string? StreetLine2,
+    string City,
+    string State,
+    string ZipCode);
+
+public record GetDraftOrderResponse(
+    int Id,
+    string Status,
+    IReadOnlyList<GetDraftOrderItemResponse> Items,
+    GetDraftOrderAddressResponse? ShippingAddress,
+    GetDraftOrderAddressResponse? BillingAddress);
+
 public record AddressRequest(
     string RecipientName,
     string StreetLine1,

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Models.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Models.cs
@@ -1,0 +1,126 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace WidgetDepot.Web.Features.Orders.Create.Step2;
+
+public class Step2FormModel
+{
+    [Required(ErrorMessage = "Recipient name is required.")]
+    [MaxLength(100, ErrorMessage = "Recipient name must not exceed 100 characters.")]
+    public string ShippingRecipientName { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Street line 1 is required.")]
+    [MaxLength(100, ErrorMessage = "Street line 1 must not exceed 100 characters.")]
+    public string ShippingStreetLine1 { get; set; } = string.Empty;
+
+    [MaxLength(100, ErrorMessage = "Street line 2 must not exceed 100 characters.")]
+    public string? ShippingStreetLine2 { get; set; }
+
+    [Required(ErrorMessage = "City is required.")]
+    [MaxLength(100, ErrorMessage = "City must not exceed 100 characters.")]
+    public string ShippingCity { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "State is required.")]
+    public string ShippingState { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "ZIP code is required.")]
+    [RegularExpression(@"^\d{5}(-\d{4})?$", ErrorMessage = "ZIP code must be in 5-digit (12345) or ZIP+4 (12345-6789) format.")]
+    public string ShippingZipCode { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Recipient name is required.")]
+    [MaxLength(100, ErrorMessage = "Recipient name must not exceed 100 characters.")]
+    public string BillingRecipientName { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Street line 1 is required.")]
+    [MaxLength(100, ErrorMessage = "Street line 1 must not exceed 100 characters.")]
+    public string BillingStreetLine1 { get; set; } = string.Empty;
+
+    [MaxLength(100, ErrorMessage = "Street line 2 must not exceed 100 characters.")]
+    public string? BillingStreetLine2 { get; set; }
+
+    [Required(ErrorMessage = "City is required.")]
+    [MaxLength(100, ErrorMessage = "City must not exceed 100 characters.")]
+    public string BillingCity { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "State is required.")]
+    public string BillingState { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "ZIP code is required.")]
+    [RegularExpression(@"^\d{5}(-\d{4})?$", ErrorMessage = "ZIP code must be in 5-digit (12345) or ZIP+4 (12345-6789) format.")]
+    public string BillingZipCode { get; set; } = string.Empty;
+}
+
+public static class UsStates
+{
+    public static readonly IReadOnlyList<(string Code, string Name)> All =
+    [
+        ("AL", "Alabama"),
+        ("AK", "Alaska"),
+        ("AZ", "Arizona"),
+        ("AR", "Arkansas"),
+        ("CA", "California"),
+        ("CO", "Colorado"),
+        ("CT", "Connecticut"),
+        ("DE", "Delaware"),
+        ("DC", "District of Columbia"),
+        ("FL", "Florida"),
+        ("GA", "Georgia"),
+        ("HI", "Hawaii"),
+        ("ID", "Idaho"),
+        ("IL", "Illinois"),
+        ("IN", "Indiana"),
+        ("IA", "Iowa"),
+        ("KS", "Kansas"),
+        ("KY", "Kentucky"),
+        ("LA", "Louisiana"),
+        ("ME", "Maine"),
+        ("MD", "Maryland"),
+        ("MA", "Massachusetts"),
+        ("MI", "Michigan"),
+        ("MN", "Minnesota"),
+        ("MS", "Mississippi"),
+        ("MO", "Missouri"),
+        ("MT", "Montana"),
+        ("NE", "Nebraska"),
+        ("NV", "Nevada"),
+        ("NH", "New Hampshire"),
+        ("NJ", "New Jersey"),
+        ("NM", "New Mexico"),
+        ("NY", "New York"),
+        ("NC", "North Carolina"),
+        ("ND", "North Dakota"),
+        ("OH", "Ohio"),
+        ("OK", "Oklahoma"),
+        ("OR", "Oregon"),
+        ("PA", "Pennsylvania"),
+        ("RI", "Rhode Island"),
+        ("SC", "South Carolina"),
+        ("SD", "South Dakota"),
+        ("TN", "Tennessee"),
+        ("TX", "Texas"),
+        ("UT", "Utah"),
+        ("VT", "Vermont"),
+        ("VA", "Virginia"),
+        ("WA", "Washington"),
+        ("WV", "West Virginia"),
+        ("WI", "Wisconsin"),
+        ("WY", "Wyoming"),
+    ];
+}
+
+public record AddressRequest(
+    string RecipientName,
+    string StreetLine1,
+    string? StreetLine2,
+    string City,
+    string State,
+    string ZipCode);
+
+public record SaveAddressesRequest(AddressRequest ShippingAddress, AddressRequest BillingAddress);
+
+public abstract record SaveAddressesResult
+{
+    public record Success : SaveAddressesResult;
+    public record NotFound : SaveAddressesResult;
+    public record Forbidden : SaveAddressesResult;
+    public record Failure : SaveAddressesResult;
+}

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
@@ -137,12 +137,25 @@
     public int OrderId { get; set; }
 
     private readonly Step2FormModel form = new();
+    private GetDraftOrderResponse? order;
     private string? errorMessage;
     private bool isSubmitting;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         if (OrderId <= 0)
+        {
+            NavigationManager.NavigateTo("/orders/new");
+            return;
+        }
+
+        var result = await Step2Service.GetDraftOrderAsync(OrderId);
+
+        if (result is GetDraftOrderResult.Success success)
+        {
+            order = success.Order;
+        }
+        else
         {
             NavigationManager.NavigateTo("/orders/new");
             return;

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
@@ -1,0 +1,243 @@
+@page "/orders/{OrderId:int}/address"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
+@using WidgetDepot.Web.Features.Orders.Create
+@using WidgetDepot.Web.Features.Orders.Create.Step2
+@inject Step2Service Step2Service
+@inject NavigationManager NavigationManager
+@inject OrderWizardState WizardState
+
+<PageTitle>New Order - Addresses</PageTitle>
+
+<h1>New Order</h1>
+<p class="text-muted lead">Step 2 of 3: Shipping &amp; Billing Addresses</p>
+
+<EditForm Model="form" OnValidSubmit="HandleContinue">
+    <DataAnnotationsValidator />
+
+    <div class="row g-4">
+        <div class="col-md-6">
+            <h2 class="h5">Shipping Address</h2>
+
+            <div class="mb-3">
+                <label class="form-label" for="shippingRecipientName">Recipient Name</label>
+                <InputText id="shippingRecipientName" class="form-control" @bind-Value="form.ShippingRecipientName" />
+                <ValidationMessage For="() => form.ShippingRecipientName" class="text-danger" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="shippingStreetLine1">Street Line 1</label>
+                <InputText id="shippingStreetLine1" class="form-control" @bind-Value="form.ShippingStreetLine1" />
+                <ValidationMessage For="() => form.ShippingStreetLine1" class="text-danger" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="shippingStreetLine2">Street Line 2 <span class="text-muted">(optional)</span></label>
+                <InputText id="shippingStreetLine2" class="form-control" @bind-Value="form.ShippingStreetLine2" />
+                <ValidationMessage For="() => form.ShippingStreetLine2" class="text-danger" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="shippingCity">City</label>
+                <InputText id="shippingCity" class="form-control" @bind-Value="form.ShippingCity" />
+                <ValidationMessage For="() => form.ShippingCity" class="text-danger" />
+            </div>
+
+            <div class="row g-2">
+                <div class="col-md-7 mb-3">
+                    <label class="form-label" for="shippingState">State</label>
+                    <InputSelect id="shippingState" class="form-select" @bind-Value="form.ShippingState">
+                        <option value="">— Select state —</option>
+                        @foreach (var state in UsStates.All)
+                        {
+                            <option value="@state.Code">@state.Name</option>
+                        }
+                    </InputSelect>
+                    <ValidationMessage For="() => form.ShippingState" class="text-danger" />
+                </div>
+                <div class="col-md-5 mb-3">
+                    <label class="form-label" for="shippingZipCode">ZIP Code</label>
+                    <InputText id="shippingZipCode" class="form-control" @bind-Value="form.ShippingZipCode" />
+                    <ValidationMessage For="() => form.ShippingZipCode" class="text-danger" />
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h2 class="h5 mb-0">Billing Address</h2>
+                <div class="form-check mb-0">
+                    <input type="checkbox" class="form-check-input" id="sameAsShipping"
+                           @onchange="HandleSameAsShipping" />
+                    <label class="form-check-label" for="sameAsShipping">Same as shipping address</label>
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="billingRecipientName">Recipient Name</label>
+                <InputText id="billingRecipientName" class="form-control" @bind-Value="form.BillingRecipientName" />
+                <ValidationMessage For="() => form.BillingRecipientName" class="text-danger" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="billingStreetLine1">Street Line 1</label>
+                <InputText id="billingStreetLine1" class="form-control" @bind-Value="form.BillingStreetLine1" />
+                <ValidationMessage For="() => form.BillingStreetLine1" class="text-danger" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="billingStreetLine2">Street Line 2 <span class="text-muted">(optional)</span></label>
+                <InputText id="billingStreetLine2" class="form-control" @bind-Value="form.BillingStreetLine2" />
+                <ValidationMessage For="() => form.BillingStreetLine2" class="text-danger" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="billingCity">City</label>
+                <InputText id="billingCity" class="form-control" @bind-Value="form.BillingCity" />
+                <ValidationMessage For="() => form.BillingCity" class="text-danger" />
+            </div>
+
+            <div class="row g-2">
+                <div class="col-md-7 mb-3">
+                    <label class="form-label" for="billingState">State</label>
+                    <InputSelect id="billingState" class="form-select" @bind-Value="form.BillingState">
+                        <option value="">— Select state —</option>
+                        @foreach (var state in UsStates.All)
+                        {
+                            <option value="@state.Code">@state.Name</option>
+                        }
+                    </InputSelect>
+                    <ValidationMessage For="() => form.BillingState" class="text-danger" />
+                </div>
+                <div class="col-md-5 mb-3">
+                    <label class="form-label" for="billingZipCode">ZIP Code</label>
+                    <InputText id="billingZipCode" class="form-control" @bind-Value="form.BillingZipCode" />
+                    <ValidationMessage For="() => form.BillingZipCode" class="text-danger" />
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @if (errorMessage is not null)
+    {
+        <div class="alert alert-danger mt-3">@errorMessage</div>
+    }
+
+    <div class="mt-4 d-flex gap-2">
+        <button type="button" class="btn btn-secondary" @onclick="HandleBack">Back</button>
+        <button type="submit" class="btn btn-primary" disabled="@isSubmitting">
+            @(isSubmitting ? "Saving..." : "Continue")
+        </button>
+    </div>
+</EditForm>
+
+@code {
+    [Parameter]
+    public int OrderId { get; set; }
+
+    private readonly Step2FormModel form = new();
+    private string? errorMessage;
+    private bool isSubmitting;
+
+    protected override void OnInitialized()
+    {
+        if (OrderId <= 0)
+        {
+            NavigationManager.NavigateTo("/orders/new");
+            return;
+        }
+
+        if (WizardState.OrderId == OrderId)
+        {
+            CopyFromState();
+        }
+    }
+
+    private void CopyFromState()
+    {
+        var saved = WizardState.AddressData;
+        form.ShippingRecipientName = saved.ShippingRecipientName;
+        form.ShippingStreetLine1 = saved.ShippingStreetLine1;
+        form.ShippingStreetLine2 = saved.ShippingStreetLine2;
+        form.ShippingCity = saved.ShippingCity;
+        form.ShippingState = saved.ShippingState;
+        form.ShippingZipCode = saved.ShippingZipCode;
+        form.BillingRecipientName = saved.BillingRecipientName;
+        form.BillingStreetLine1 = saved.BillingStreetLine1;
+        form.BillingStreetLine2 = saved.BillingStreetLine2;
+        form.BillingCity = saved.BillingCity;
+        form.BillingState = saved.BillingState;
+        form.BillingZipCode = saved.BillingZipCode;
+    }
+
+    private void SaveToState()
+    {
+        WizardState.OrderId = OrderId;
+        var target = WizardState.AddressData;
+        target.ShippingRecipientName = form.ShippingRecipientName;
+        target.ShippingStreetLine1 = form.ShippingStreetLine1;
+        target.ShippingStreetLine2 = form.ShippingStreetLine2;
+        target.ShippingCity = form.ShippingCity;
+        target.ShippingState = form.ShippingState;
+        target.ShippingZipCode = form.ShippingZipCode;
+        target.BillingRecipientName = form.BillingRecipientName;
+        target.BillingStreetLine1 = form.BillingStreetLine1;
+        target.BillingStreetLine2 = form.BillingStreetLine2;
+        target.BillingCity = form.BillingCity;
+        target.BillingState = form.BillingState;
+        target.BillingZipCode = form.BillingZipCode;
+    }
+
+    private void HandleSameAsShipping(ChangeEventArgs e)
+    {
+        if (e.Value is true)
+        {
+            form.BillingRecipientName = form.ShippingRecipientName;
+            form.BillingStreetLine1 = form.ShippingStreetLine1;
+            form.BillingStreetLine2 = form.ShippingStreetLine2;
+            form.BillingCity = form.ShippingCity;
+            form.BillingState = form.ShippingState;
+            form.BillingZipCode = form.ShippingZipCode;
+        }
+    }
+
+    private void HandleBack()
+    {
+        SaveToState();
+        NavigationManager.NavigateTo("/orders/new");
+    }
+
+    private async Task HandleContinue()
+    {
+        isSubmitting = true;
+        errorMessage = null;
+
+        try
+        {
+            var result = await Step2Service.SaveAddressesAsync(OrderId, form);
+
+            switch (result)
+            {
+                case SaveAddressesResult.Success:
+                    NavigationManager.NavigateTo($"/orders/{OrderId}/shipping");
+                    break;
+                case SaveAddressesResult.NotFound:
+                case SaveAddressesResult.Forbidden:
+                    NavigationManager.NavigateTo("/orders/new");
+                    break;
+                default:
+                    errorMessage = "An unexpected error occurred. Please try again.";
+                    break;
+            }
+        }
+        catch (Exception)
+        {
+            errorMessage = "An unexpected error occurred. Please try again.";
+        }
+        finally
+        {
+            isSubmitting = false;
+        }
+    }
+}

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Service.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Service.cs
@@ -3,6 +3,14 @@ using System.Net.Http.Json;
 
 namespace WidgetDepot.Web.Features.Orders.Create.Step2;
 
+public abstract record GetDraftOrderResult
+{
+    public record Success(GetDraftOrderResponse Order) : GetDraftOrderResult;
+    public record NotFound : GetDraftOrderResult;
+    public record Forbidden : GetDraftOrderResult;
+    public record Failure : GetDraftOrderResult;
+}
+
 public class Step2Service
 {
     private readonly HttpClient _httpClient;
@@ -10,6 +18,26 @@ public class Step2Service
     public Step2Service(HttpClient httpClient)
     {
         _httpClient = httpClient;
+    }
+
+    public async Task<GetDraftOrderResult> GetDraftOrderAsync(int orderId, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync($"/orders/{orderId}/draft", cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var order = await response.Content.ReadFromJsonAsync<GetDraftOrderResponse>(cancellationToken);
+            return order is null
+                ? new GetDraftOrderResult.Failure()
+                : new GetDraftOrderResult.Success(order);
+        }
+
+        return response.StatusCode switch
+        {
+            HttpStatusCode.NotFound => new GetDraftOrderResult.NotFound(),
+            HttpStatusCode.Forbidden => new GetDraftOrderResult.Forbidden(),
+            _ => new GetDraftOrderResult.Failure()
+        };
     }
 
     public async Task<SaveAddressesResult> SaveAddressesAsync(int orderId, Step2FormModel form, CancellationToken cancellationToken = default)

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Service.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Service.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace WidgetDepot.Web.Features.Orders.Create.Step2;
+
+public class Step2Service
+{
+    private readonly HttpClient _httpClient;
+
+    public Step2Service(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<SaveAddressesResult> SaveAddressesAsync(int orderId, Step2FormModel form, CancellationToken cancellationToken = default)
+    {
+        var request = new SaveAddressesRequest(
+            new AddressRequest(
+                form.ShippingRecipientName,
+                form.ShippingStreetLine1,
+                NullIfEmpty(form.ShippingStreetLine2),
+                form.ShippingCity,
+                form.ShippingState,
+                form.ShippingZipCode),
+            new AddressRequest(
+                form.BillingRecipientName,
+                form.BillingStreetLine1,
+                NullIfEmpty(form.BillingStreetLine2),
+                form.BillingCity,
+                form.BillingState,
+                form.BillingZipCode));
+
+        var response = await _httpClient.PostAsJsonAsync($"/orders/{orderId}/addresses", request, cancellationToken);
+
+        return response.StatusCode switch
+        {
+            HttpStatusCode.NoContent => new SaveAddressesResult.Success(),
+            HttpStatusCode.NotFound => new SaveAddressesResult.NotFound(),
+            HttpStatusCode.Forbidden => new SaveAddressesResult.Forbidden(),
+            _ => new SaveAddressesResult.Failure()
+        };
+    }
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+}

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -11,7 +11,9 @@ using WidgetDepot.Web.Features.Accounts.Profile;
 using WidgetDepot.Web.Features.Accounts.Register;
 using WidgetDepot.Web.Features.Admin.CatalogImport;
 using WidgetDepot.Web.Features.Catalog;
+using WidgetDepot.Web.Features.Orders.Create;
 using WidgetDepot.Web.Features.Orders.Create.Step1;
+using WidgetDepot.Web.Features.Orders.Create.Step2;
 using WidgetDepot.Web.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -59,6 +61,12 @@ builder.Services.AddHttpClient<PasswordChangeService>(client =>
 builder.Services.AddHttpClient<Step1Service>(client =>
     client.BaseAddress = new Uri("https+http://apiservice"))
     .AddHttpMessageHandler<CookieForwardingHandler>();
+
+builder.Services.AddHttpClient<Step2Service>(client =>
+    client.BaseAddress = new Uri("https+http://apiservice"))
+    .AddHttpMessageHandler<CookieForwardingHandler>();
+
+builder.Services.AddScoped<OrderWizardState>();
 
 var app = builder.Build();
 

--- a/tests/WidgetDepot.Tests/Features/Orders/Create/Step2/Step2ServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/Create/Step2/Step2ServiceTests.cs
@@ -33,6 +33,52 @@ public class Step2ServiceTests
     };
 
     [Fact]
+    public async Task GetDraftOrderAsync_OkResponse_ReturnsSuccessWithOrder()
+    {
+        var json = """{"id":1,"status":"Draft","items":[],"shippingAddress":null,"billingAddress":null}""";
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK, responseContent: json);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        var service = new Step2Service(httpClient);
+
+        var result = await service.GetDraftOrderAsync(1, TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetDraftOrderResult.Success>();
+        success.Order.Id.ShouldBe(1);
+        success.Order.Status.ShouldBe("Draft");
+        success.Order.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetDraftOrderAsync_NotFoundResponse_ReturnsNotFound()
+    {
+        var service = CreateService(HttpStatusCode.NotFound);
+
+        var result = await service.GetDraftOrderAsync(999, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftOrderResult.NotFound>();
+    }
+
+    [Fact]
+    public async Task GetDraftOrderAsync_ForbiddenResponse_ReturnsForbidden()
+    {
+        var service = CreateService(HttpStatusCode.Forbidden);
+
+        var result = await service.GetDraftOrderAsync(1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftOrderResult.Forbidden>();
+    }
+
+    [Fact]
+    public async Task GetDraftOrderAsync_ServerErrorResponse_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError);
+
+        var result = await service.GetDraftOrderAsync(1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftOrderResult.Failure>();
+    }
+
+    [Fact]
     public async Task SaveAddressesAsync_NoContentResponse_ReturnsSuccess()
     {
         var service = CreateService(HttpStatusCode.NoContent);
@@ -93,11 +139,13 @@ public class Step2ServiceTests
     {
         private readonly HttpStatusCode _statusCode;
         private readonly Action<string>? _bodyCapture;
+        private readonly string _responseContent;
 
-        public FakeHttpMessageHandler(HttpStatusCode statusCode, Action<string>? bodyCapture = null)
+        public FakeHttpMessageHandler(HttpStatusCode statusCode, Action<string>? bodyCapture = null, string? responseContent = null)
         {
             _statusCode = statusCode;
             _bodyCapture = bodyCapture;
+            _responseContent = responseContent ?? "{}";
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -110,7 +158,7 @@ public class Step2ServiceTests
 
             return new HttpResponseMessage(_statusCode)
             {
-                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                Content = new StringContent(_responseContent, Encoding.UTF8, "application/json")
             };
         }
     }

--- a/tests/WidgetDepot.Tests/Features/Orders/Create/Step2/Step2ServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/Create/Step2/Step2ServiceTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Text;
+
+using Shouldly;
+
+using WidgetDepot.Web.Features.Orders.Create.Step2;
+
+namespace WidgetDepot.Tests.Features.Orders.Create.Step2;
+
+public class Step2ServiceTests
+{
+    private static Step2Service CreateService(HttpStatusCode statusCode)
+    {
+        var handler = new FakeHttpMessageHandler(statusCode);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        return new Step2Service(httpClient);
+    }
+
+    private static Step2FormModel ValidForm() => new()
+    {
+        ShippingRecipientName = "Alice Smith",
+        ShippingStreetLine1 = "123 Main St",
+        ShippingStreetLine2 = null,
+        ShippingCity = "Springfield",
+        ShippingState = "IL",
+        ShippingZipCode = "62701",
+        BillingRecipientName = "Bob Jones",
+        BillingStreetLine1 = "456 Oak Ave",
+        BillingStreetLine2 = "Apt 2",
+        BillingCity = "Shelbyville",
+        BillingState = "IL",
+        BillingZipCode = "62565-1234"
+    };
+
+    [Fact]
+    public async Task SaveAddressesAsync_NoContentResponse_ReturnsSuccess()
+    {
+        var service = CreateService(HttpStatusCode.NoContent);
+
+        var result = await service.SaveAddressesAsync(1, ValidForm(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SaveAddressesResult.Success>();
+    }
+
+    [Fact]
+    public async Task SaveAddressesAsync_NotFoundResponse_ReturnsNotFound()
+    {
+        var service = CreateService(HttpStatusCode.NotFound);
+
+        var result = await service.SaveAddressesAsync(999, ValidForm(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SaveAddressesResult.NotFound>();
+    }
+
+    [Fact]
+    public async Task SaveAddressesAsync_ForbiddenResponse_ReturnsForbidden()
+    {
+        var service = CreateService(HttpStatusCode.Forbidden);
+
+        var result = await service.SaveAddressesAsync(1, ValidForm(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SaveAddressesResult.Forbidden>();
+    }
+
+    [Fact]
+    public async Task SaveAddressesAsync_ServerErrorResponse_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError);
+
+        var result = await service.SaveAddressesAsync(1, ValidForm(), TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SaveAddressesResult.Failure>();
+    }
+
+    [Fact]
+    public async Task SaveAddressesAsync_EmptyStreetLine2_SendsNullInRequest()
+    {
+        string? capturedBody = null;
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.NoContent, body => capturedBody = body);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        var service = new Step2Service(httpClient);
+
+        var form = ValidForm();
+        form.ShippingStreetLine2 = "   ";
+
+        await service.SaveAddressesAsync(1, form, TestContext.Current.CancellationToken);
+
+        capturedBody.ShouldNotBeNull();
+        capturedBody.ShouldContain("\"streetLine2\":null");
+    }
+
+    private class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly Action<string>? _bodyCapture;
+
+        public FakeHttpMessageHandler(HttpStatusCode statusCode, Action<string>? bodyCapture = null)
+        {
+            _statusCode = statusCode;
+            _bodyCapture = bodyCapture;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (_bodyCapture is not null && request.Content is not null)
+            {
+                var body = await request.Content.ReadAsStringAsync(cancellationToken);
+                _bodyCapture(body);
+            }
+
+            return new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+            };
+        }
+    }
+}

--- a/tests/WidgetDepot.Tests/Features/Orders/GetDraftOrder/GetDraftOrderHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/GetDraftOrder/GetDraftOrderHandlerTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.EntityFrameworkCore;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
+
+namespace WidgetDepot.Tests.Features.Orders.GetDraftOrder;
+
+public class GetDraftOrderHandlerTests
+{
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static async Task<Order> SeedOrderAsync(AppDbContext db, int customerId = 1)
+    {
+        var order = new Order
+        {
+            CustomerId = customerId,
+            Status = OrderStatus.Draft,
+            CreatedAt = DateTime.UtcNow
+        };
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return order;
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderNotFound_ReturnsOrderNotFound()
+    {
+        using var db = CreateDb();
+        var handler = new GetDraftOrderHandler(db);
+
+        var result = await handler.HandleAsync(999, 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftOrderError.OrderNotFound>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderBelongsToDifferentCustomer_ReturnsForbidden()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1);
+        var handler = new GetDraftOrderHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, 2, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftOrderError.Forbidden>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderExistsAndBelongsToCustomer_ReturnsResponse()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1);
+        var handler = new GetDraftOrderHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, 1, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<GetDraftOrderResponse>();
+        response.Id.ShouldBe(order.Id);
+        response.Status.ShouldBe("Draft");
+        response.Items.ShouldBeEmpty();
+        response.ShippingAddress.ShouldBeNull();
+        response.BillingAddress.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Implements Step 2 of the order creation wizard at `/orders/{orderId}/address`
- Shipping and billing address form with all 50 US states + DC dropdown, ZIP code validation, and 100-character limits on text fields
- "Same as shipping address" one-time copy toggle (unchecked by default)
- Back/Continue buttons with wizard state preserved across navigation via a new scoped `OrderWizardState` service
- Also upgrades the `github-workflow.md` reference in `CLAUDE.md` from passive "refer to" to "MUST read and follow" so the full local workflow is followed automatically

## Test plan

- [x] Build passes: `dotnet build`
- [x] All tests pass: `dotnet test` (5 new Step2ServiceTests added)
- [x] Navigate directly to `/orders/999/address` — should redirect to `/orders/new`
- [x] Complete Step 1, click Continue — should land on Step 2 with correct orderId in URL
- [x] Submit with empty fields — should show validation messages, not proceed
- [x] Enter a name > 100 chars — should show max-length validation message
- [x] Enter invalid ZIP (`1234`, `ABCDE`) — should show format error
- [x] Check "Same as shipping" — billing fields should copy from shipping and remain editable
- [x] Click Back — should return to Step 1 with widget selections and address data restored
- [x] Submit valid addresses — should call SaveAddresses API and navigate to `/orders/{id}/shipping`

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)