### PR TITLE
feat: implement CalculateShipping endpoint and Order.ShippingEstimate column

### DIFF
--- a/src/WidgetDepot.ApiService/Data/AppDbContext.cs
+++ b/src/WidgetDepot.ApiService/Data/AppDbContext.cs
@@ -63,6 +63,8 @@ public class AppDbContext : DbContext
                 a.Property(x => x.ZipCode).HasColumnName("BillingZipCode").HasColumnType("text");
             });
             entity.Navigation(o => o.BillingAddress).IsRequired(false);
+
+            entity.Property(o => o.ShippingEstimate).HasPrecision(10, 2);
         });
 
     }

--- a/src/WidgetDepot.ApiService/Data/Migrations/20260502102124_AddOrderShippingEstimate.Designer.cs
+++ b/src/WidgetDepot.ApiService/Data/Migrations/20260502102124_AddOrderShippingEstimate.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WidgetDepot.ApiService.Data;
@@ -11,9 +12,11 @@ using WidgetDepot.ApiService.Data;
 namespace WidgetDepot.ApiService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260502102124_AddOrderShippingEstimate")]
+    partial class AddOrderShippingEstimate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WidgetDepot.ApiService/Data/Migrations/20260502102124_AddOrderShippingEstimate.cs
+++ b/src/WidgetDepot.ApiService/Data/Migrations/20260502102124_AddOrderShippingEstimate.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WidgetDepot.ApiService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrderShippingEstimate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "ShippingEstimate",
+                table: "Orders",
+                type: "numeric(10,2)",
+                precision: 10,
+                scale: 2,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ShippingEstimate",
+                table: "Orders");
+        }
+    }
+}

--- a/src/WidgetDepot.ApiService/Data/Order.cs
+++ b/src/WidgetDepot.ApiService/Data/Order.cs
@@ -16,4 +16,5 @@ public class Order
     public ICollection<OrderItem> Items { get; set; } = [];
     public Address? ShippingAddress { get; set; }
     public Address? BillingAddress { get; set; }
+    public decimal? ShippingEstimate { get; set; }
 }

--- a/src/WidgetDepot.ApiService/Features/Orders/CalculateShipping/CalculateShippingEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/CalculateShipping/CalculateShippingEndpoint.cs
@@ -1,0 +1,39 @@
+using System.Security.Claims;
+
+namespace WidgetDepot.ApiService.Features.Orders.CalculateShipping;
+
+public static class CalculateShippingEndpoint
+{
+    public static IEndpointRouteBuilder MapCalculateShipping(this IEndpointRouteBuilder app)
+    {
+        app.MapPost(OrderEndpoints.CalculateShipping, async (
+            int orderId,
+            ClaimsPrincipal user,
+            CalculateShippingHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            if (!user.TryGetCustomerId(out var customerId))
+                return Results.Unauthorized();
+
+            var result = await handler.HandleAsync(orderId, customerId, cancellationToken);
+
+            return result switch
+            {
+                CalculateShippingError.OrderNotFound => Results.NotFound(),
+                CalculateShippingError.Forbidden => Results.Forbid(),
+                CalculateShippingError.NoShippingAddress => Results.Problem(
+                    detail: "Shipping address is required before calculating shipping.",
+                    statusCode: StatusCodes.Status422UnprocessableEntity),
+                CalculateShippingError.ShippingApiFailure error => Results.Problem(
+                    detail: error.Reason,
+                    statusCode: StatusCodes.Status502BadGateway),
+                CalculateShippingResponse response => Results.Ok(response),
+                _ => Results.Problem(statusCode: 500)
+            };
+        })
+        .WithName("CalculateShipping")
+        .RequireAuthorization();
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/CalculateShipping/CalculateShippingHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/CalculateShipping/CalculateShippingHandler.cs
@@ -1,0 +1,79 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Orders.CalculateShipping;
+
+public record CalculateShippingResponse(decimal EstimatedCost, string Currency);
+
+public abstract record CalculateShippingError
+{
+    public record OrderNotFound : CalculateShippingError;
+    public record Forbidden : CalculateShippingError;
+    public record NoShippingAddress : CalculateShippingError;
+    public record ShippingApiFailure(string Reason) : CalculateShippingError;
+}
+
+public class CalculateShippingHandler
+{
+    private readonly AppDbContext _db;
+    private readonly IShippingApiClient _shippingApiClient;
+    private readonly string _originPostalCode;
+    private readonly string _originCountry;
+
+    public CalculateShippingHandler(AppDbContext db, IShippingApiClient shippingApiClient, IConfiguration configuration)
+    {
+        _db = db;
+        _shippingApiClient = shippingApiClient;
+        _originPostalCode = configuration["Shipping:OriginPostalCode"] ?? "10001";
+        _originCountry = configuration["Shipping:OriginCountry"] ?? "US";
+    }
+
+    public async Task<object> HandleAsync(int orderId, int customerId, CancellationToken cancellationToken)
+    {
+        var order = await _db.Orders
+            .Include(o => o.Items)
+            .FirstOrDefaultAsync(o => o.Id == orderId, cancellationToken);
+
+        if (order is null)
+            return new CalculateShippingError.OrderNotFound();
+
+        if (order.CustomerId != customerId)
+            return new CalculateShippingError.Forbidden();
+
+        if (order.ShippingAddress is null)
+            return new CalculateShippingError.NoShippingAddress();
+
+        var totalWeight = await CalculateTotalWeightAsync(order.Items, cancellationToken);
+
+        var request = new ShippingEstimateRequest(
+            _originPostalCode,
+            _originCountry,
+            order.ShippingAddress.ZipCode,
+            "US",
+            totalWeight);
+
+        var result = await _shippingApiClient.GetEstimateAsync(request, cancellationToken);
+
+        if (result is ShippingEstimateResult.Failure failure)
+            return new CalculateShippingError.ShippingApiFailure(failure.Reason);
+
+        var success = (ShippingEstimateResult.Success)result;
+        order.ShippingEstimate = success.EstimatedCost;
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return new CalculateShippingResponse(success.EstimatedCost, success.Currency);
+    }
+
+    private async Task<decimal> CalculateTotalWeightAsync(ICollection<OrderItem> items, CancellationToken cancellationToken)
+    {
+        var widgetIds = items.Select(i => i.WidgetId).ToList();
+
+        var widgetWeights = await _db.Widgets
+            .Where(w => widgetIds.Contains(w.Id))
+            .ToDictionaryAsync(w => w.Id, w => w.Weight, cancellationToken);
+
+        return items.Sum(i => i.Quantity * widgetWeights.GetValueOrDefault(i.WidgetId, 0m));
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
@@ -1,3 +1,4 @@
+using WidgetDepot.ApiService.Features.Orders.CalculateShipping;
 using WidgetDepot.ApiService.Features.Orders.CreateDraft;
 using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
@@ -11,6 +12,7 @@ public static class OrderEndpointExtensions
         app.MapCreateDraftOrder();
         app.MapGetDraftOrder();
         app.MapSaveAddresses();
+        app.MapCalculateShipping();
 
         return app;
     }

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
@@ -7,4 +7,5 @@ public static class OrderEndpoints
     public const string CreateDraft = $"{Base}/draft";
     public const string SaveAddresses = $"{Base}/{{orderId}}/addresses";
     public const string GetDraftOrder = $"{Base}/{{orderId}}/draft";
+    public const string CalculateShipping = $"{Base}/{{orderId}}/shipping-estimate";
 }

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -53,6 +53,7 @@ builder.Services.AddScoped<IShippingApiClient, AcmeShippingApiClient>();
 builder.Services.AddScoped<CreateDraftOrderHandler>();
 builder.Services.AddScoped<GetDraftOrderHandler>();
 builder.Services.AddScoped<SaveAddressesHandler>();
+builder.Services.AddScoped<CalculateShippingHandler>();
 builder.Services.AddScoped<SearchWidgetsHandler>();
 builder.Services.AddScoped<ImportWidgetsCsvHandler>();
 builder.Services.AddScoped<RegisterHandler>();

--- a/tests/WidgetDepot.Tests/Features/Orders/CalculateShipping/CalculateShippingHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/CalculateShipping/CalculateShippingHandlerTests.cs
@@ -1,0 +1,265 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
+using Moq;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.CalculateShipping;
+
+namespace WidgetDepot.Tests.Features.Orders.CalculateShipping;
+
+public class CalculateShippingHandlerTests
+{
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static IConfiguration EmptyConfiguration() =>
+        new ConfigurationBuilder().Build();
+
+    private static CalculateShippingHandler CreateHandler(
+        AppDbContext db,
+        IShippingApiClient shippingApiClient,
+        IConfiguration? configuration = null) =>
+        new(db, shippingApiClient, configuration ?? EmptyConfiguration());
+
+    private static async Task<Order> SeedOrderWithShippingAddressAsync(AppDbContext db, int customerId = 1)
+    {
+        var order = new Order
+        {
+            CustomerId = customerId,
+            Status = OrderStatus.Draft,
+            CreatedAt = DateTime.UtcNow,
+            ShippingAddress = new Address
+            {
+                RecipientName = "Alice Smith",
+                StreetLine1 = "123 Main St",
+                City = "Springfield",
+                State = "IL",
+                ZipCode = "62701"
+            }
+        };
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return order;
+    }
+
+    private static async Task<(Order order, Widget widget)> SeedOrderWithItemsAsync(
+        AppDbContext db,
+        int customerId = 1,
+        decimal widgetWeight = 2.5m,
+        int quantity = 3)
+    {
+        var widget = new Widget
+        {
+            Id = 1,
+            Sku = "WGT-001",
+            Name = "Test Widget",
+            Weight = widgetWeight
+        };
+        db.Widgets.Add(widget);
+
+        var order = new Order
+        {
+            CustomerId = customerId,
+            Status = OrderStatus.Draft,
+            CreatedAt = DateTime.UtcNow,
+            ShippingAddress = new Address
+            {
+                RecipientName = "Alice Smith",
+                StreetLine1 = "123 Main St",
+                City = "Springfield",
+                State = "IL",
+                ZipCode = "62701"
+            }
+        };
+        order.Items.Add(new OrderItem { WidgetId = widget.Id, Quantity = quantity });
+        db.Orders.Add(order);
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return (order, widget);
+    }
+
+    [Fact]
+    public async Task HandleAsync_SuccessfulApiResponse_ReturnsEstimate()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedOrderWithItemsAsync(db, widgetWeight: 2.0m, quantity: 3);
+
+        var mockClient = new Mock<IShippingApiClient>();
+        mockClient.Setup(c => c.GetEstimateAsync(It.IsAny<ShippingEstimateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ShippingEstimateResult.Success(19.99m, "USD"));
+
+        var handler = CreateHandler(db, mockClient.Object);
+        var result = await handler.HandleAsync(order.Id, 1, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<CalculateShippingResponse>();
+        response.EstimatedCost.ShouldBe(19.99m);
+        response.Currency.ShouldBe("USD");
+    }
+
+    [Fact]
+    public async Task HandleAsync_SuccessfulApiResponse_StoresEstimateOnOrder()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedOrderWithItemsAsync(db);
+
+        var mockClient = new Mock<IShippingApiClient>();
+        mockClient.Setup(c => c.GetEstimateAsync(It.IsAny<ShippingEstimateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ShippingEstimateResult.Success(14.50m, "USD"));
+
+        var handler = CreateHandler(db, mockClient.Object);
+        await handler.HandleAsync(order.Id, 1, TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.ShippingEstimate.ShouldBe(14.50m);
+    }
+
+    [Fact]
+    public async Task HandleAsync_MultipleItems_SendsCorrectTotalWeight()
+    {
+        using var db = CreateDb();
+        var widget1 = new Widget { Id = 1, Sku = "W-001", Name = "Widget 1", Weight = 2.0m };
+        var widget2 = new Widget { Id = 2, Sku = "W-002", Name = "Widget 2", Weight = 3.0m };
+        db.Widgets.AddRange(widget1, widget2);
+
+        var order = new Order
+        {
+            CustomerId = 1,
+            Status = OrderStatus.Draft,
+            CreatedAt = DateTime.UtcNow,
+            ShippingAddress = new Address
+            {
+                RecipientName = "Bob Jones",
+                StreetLine1 = "456 Oak Ave",
+                City = "Shelbyville",
+                State = "IL",
+                ZipCode = "62565"
+            }
+        };
+        order.Items.Add(new OrderItem { WidgetId = 1, Quantity = 2 });
+        order.Items.Add(new OrderItem { WidgetId = 2, Quantity = 4 });
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        ShippingEstimateRequest? capturedRequest = null;
+        var mockClient = new Mock<IShippingApiClient>();
+        mockClient.Setup(c => c.GetEstimateAsync(It.IsAny<ShippingEstimateRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<ShippingEstimateRequest, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new ShippingEstimateResult.Success(25.00m, "USD"));
+
+        var handler = CreateHandler(db, mockClient.Object);
+        await handler.HandleAsync(order.Id, 1, TestContext.Current.CancellationToken);
+
+        // widget1: 2 × 2.0 = 4.0, widget2: 4 × 3.0 = 12.0 → total = 16.0
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.WeightLbs.ShouldBe(16.0m);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DestinationAddressSentToApi()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedOrderWithItemsAsync(db);
+
+        ShippingEstimateRequest? capturedRequest = null;
+        var mockClient = new Mock<IShippingApiClient>();
+        mockClient.Setup(c => c.GetEstimateAsync(It.IsAny<ShippingEstimateRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<ShippingEstimateRequest, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new ShippingEstimateResult.Success(10.00m, "USD"));
+
+        var handler = CreateHandler(db, mockClient.Object);
+        await handler.HandleAsync(order.Id, 1, TestContext.Current.CancellationToken);
+
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.DestinationPostalCode.ShouldBe("62701");
+        capturedRequest.DestinationCountry.ShouldBe("US");
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderNotFound_ReturnsOrderNotFound()
+    {
+        using var db = CreateDb();
+        var mockClient = new Mock<IShippingApiClient>();
+        var handler = CreateHandler(db, mockClient.Object);
+
+        var result = await handler.HandleAsync(999, 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<CalculateShippingError.OrderNotFound>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderBelongsToDifferentCustomer_ReturnsForbidden()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedOrderWithItemsAsync(db, customerId: 1);
+
+        var mockClient = new Mock<IShippingApiClient>();
+        var handler = CreateHandler(db, mockClient.Object);
+
+        var result = await handler.HandleAsync(order.Id, 2, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<CalculateShippingError.Forbidden>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoShippingAddress_ReturnsNoShippingAddress()
+    {
+        using var db = CreateDb();
+        var order = new Order
+        {
+            CustomerId = 1,
+            Status = OrderStatus.Draft,
+            CreatedAt = DateTime.UtcNow
+        };
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var mockClient = new Mock<IShippingApiClient>();
+        var handler = CreateHandler(db, mockClient.Object);
+
+        var result = await handler.HandleAsync(order.Id, 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<CalculateShippingError.NoShippingAddress>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ShippingApiFailure_ReturnsShippingApiFailure()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedOrderWithItemsAsync(db);
+
+        var mockClient = new Mock<IShippingApiClient>();
+        mockClient.Setup(c => c.GetEstimateAsync(It.IsAny<ShippingEstimateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ShippingEstimateResult.Failure("Service unavailable"));
+
+        var handler = CreateHandler(db, mockClient.Object);
+        var result = await handler.HandleAsync(order.Id, 1, TestContext.Current.CancellationToken);
+
+        var error = result.ShouldBeOfType<CalculateShippingError.ShippingApiFailure>();
+        error.Reason.ShouldBe("Service unavailable");
+    }
+
+    [Fact]
+    public async Task HandleAsync_ShippingApiFailure_DoesNotStoreEstimate()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedOrderWithItemsAsync(db);
+
+        var mockClient = new Mock<IShippingApiClient>();
+        mockClient.Setup(c => c.GetEstimateAsync(It.IsAny<ShippingEstimateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ShippingEstimateResult.Failure("Timeout"));
+
+        var handler = CreateHandler(db, mockClient.Object);
+        await handler.HandleAsync(order.Id, 1, TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.ShippingEstimate.ShouldBeNull();
+    }
+}

--- a/tests/WidgetDepot.Tests/WidgetDepot.Tests.csproj
+++ b/tests/WidgetDepot.Tests/WidgetDepot.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />


### PR DESCRIPTION
## Summary

- Adds `ShippingEstimate` (nullable decimal) to the `Order` entity with a precision-configured EF Core migration
- Implements `POST orders/{orderId}/shipping-estimate` endpoint that calculates total widget weight (sum of `Widget.Weight × OrderItem.Quantity`), calls `IShippingApiClient` with the destination address and weight, stores the estimate on the order, and returns it to the caller
- Returns 422 if no shipping address is set, 502 if the shipping API fails, and does not store a partial value on API failure
- Adds Moq to the test project; 8 new handler tests cover weight calculation, success/error paths, and address forwarding

## Test plan
- [x] `dotnet build` passes with no warnings
- [x] `dotnet test` passes (118 passing, 1 existing skip)
- [x] All 8 new `CalculateShippingHandlerTests` pass

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)