### PR TITLE
feat: implement order wizard step 3 - shipping estimate

### DIFF
--- a/src/WidgetDepot.ApiService/Features/Orders/CalculateShipping/AcmeShippingApiClient.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/CalculateShipping/AcmeShippingApiClient.cs
@@ -30,7 +30,7 @@ public class AcmeShippingApiClient : IShippingApiClient
 
             return new ShippingEstimateResult.Failure($"Received HTTP {(int)response.StatusCode}");
         }
-        catch (HttpRequestException ex)
+        catch (Exception ex)
         {
             return new ShippingEstimateResult.Failure(ex.Message);
         }

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -43,13 +43,12 @@ builder.Services.AddAuthorization();
 
 builder.AddNpgsqlDbContext<AppDbContext>("widgetdepot");
 
-builder.Services.AddHttpClient<AcmeShippingApiClient>(client =>
+builder.Services.AddHttpClient<IShippingApiClient, AcmeShippingApiClient>(client =>
 {
     client.BaseAddress = new Uri("https+http://shippingapi/");
     var apiKey = builder.Configuration["SHIPPING_API_KEY"] ?? "dev-api-key";
     client.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
 });
-builder.Services.AddScoped<IShippingApiClient, AcmeShippingApiClient>();
 builder.Services.AddScoped<CreateDraftOrderHandler>();
 builder.Services.AddScoped<GetDraftOrderHandler>();
 builder.Services.AddScoped<SaveAddressesHandler>();

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
@@ -233,6 +233,7 @@
             switch (result)
             {
                 case SaveAddressesResult.Success:
+                    SaveToState();
                     NavigationManager.NavigateTo($"/orders/{OrderId}/shipping");
                     break;
                 case SaveAddressesResult.NotFound:

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step3/Step3Models.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step3/Step3Models.cs
@@ -1,0 +1,38 @@
+namespace WidgetDepot.Web.Features.Orders.Create.Step3;
+
+public abstract record GetDraftOrderResult
+{
+    public record Success(GetDraftOrderResponse Order) : GetDraftOrderResult;
+    public record NotFound : GetDraftOrderResult;
+    public record Forbidden : GetDraftOrderResult;
+    public record Failure : GetDraftOrderResult;
+}
+
+public abstract record CalculateShippingResult
+{
+    public record Success(decimal EstimatedCost, string Currency) : CalculateShippingResult;
+    public record NotFound : CalculateShippingResult;
+    public record Forbidden : CalculateShippingResult;
+    public record NoShippingAddress : CalculateShippingResult;
+    public record ApiFailure : CalculateShippingResult;
+    public record Failure : CalculateShippingResult;
+}
+
+public record GetDraftOrderItemResponse(int WidgetId, int Quantity);
+
+public record GetDraftOrderAddressResponse(
+    string RecipientName,
+    string StreetLine1,
+    string? StreetLine2,
+    string City,
+    string State,
+    string ZipCode);
+
+public record GetDraftOrderResponse(
+    int Id,
+    string Status,
+    IReadOnlyList<GetDraftOrderItemResponse> Items,
+    GetDraftOrderAddressResponse? ShippingAddress,
+    GetDraftOrderAddressResponse? BillingAddress);
+
+internal record CalculateShippingResponse(decimal EstimatedCost, string Currency);

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step3/Step3Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step3/Step3Page.razor
@@ -35,11 +35,11 @@ else
 {
     <div class="mb-4">
         <h2 class="h5">Order Items</h2>
-        <table class="table table-bordered">
+        <table class="table table-hover table-sm">
             <thead>
-                <tr>
+                <tr class="table-primary">
                     <th>Widget</th>
-                    <th class="text-end">Qty</th>
+                    <th class="text-end">Quantity</th>
                     <th class="text-end">Weight (lbs)</th>
                     <th class="text-end">Subtotal (lbs)</th>
                 </tr>
@@ -58,9 +58,9 @@ else
             @if (totalWeight.HasValue)
             {
                 <tfoot>
-                    <tr class="table-secondary fw-bold">
-                        <td colspan="3" class="text-end">Total weight</td>
-                        <td class="text-end">@totalWeight.Value.ToString("0.###") lbs</td>
+                    <tr class="fw-bold">
+                        <td colspan="3" class="text-end">Total weight (lbs)</td>
+                        <td class="text-end">@totalWeight.Value.ToString("0.###")</td>
                     </tr>
                 </tfoot>
             }

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step3/Step3Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step3/Step3Page.razor
@@ -1,0 +1,226 @@
+@page "/orders/{OrderId:int}/shipping"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
+@using WidgetDepot.Web.Features.Orders.Create
+@using WidgetDepot.Web.Features.Orders.Create.Step1
+@using WidgetDepot.Web.Features.Orders.Create.Step3
+@inject Step3Service Step3Service
+@inject NavigationManager NavigationManager
+@inject OrderWizardState WizardState
+
+<PageTitle>New Order - Shipping Estimate</PageTitle>
+
+<h1>New Order</h1>
+<p class="text-muted lead">Step 3 of 3: Shipping Estimate</p>
+
+@if (isLoading)
+{
+    <p>Calculating shipping estimate&hellip;</p>
+}
+else if (loadError is not null)
+{
+    <div class="alert alert-danger">
+        <p class="mb-2">@loadError</p>
+        <button type="button" class="btn btn-warning btn-sm" @onclick="RetryAsync" disabled="@isRetrying">
+            @(isRetrying ? "Retrying..." : "Retry")
+        </button>
+    </div>
+
+    <div class="mt-3">
+        <button type="button" class="btn btn-secondary" @onclick="HandleBack">Back</button>
+    </div>
+}
+else
+{
+    <div class="mb-4">
+        <h2 class="h5">Order Items</h2>
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>Widget</th>
+                    <th class="text-end">Qty</th>
+                    <th class="text-end">Weight (lbs)</th>
+                    <th class="text-end">Subtotal (lbs)</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in displayItems)
+                {
+                    <tr>
+                        <td>@(item.Name ?? $"Widget #{item.WidgetId}")</td>
+                        <td class="text-end">@item.Quantity</td>
+                        <td class="text-end">@(item.WeightPerUnit.HasValue ? item.WeightPerUnit.Value.ToString("0.###") : "—")</td>
+                        <td class="text-end">@(item.SubtotalWeight.HasValue ? item.SubtotalWeight.Value.ToString("0.###") : "—")</td>
+                    </tr>
+                }
+            </tbody>
+            @if (totalWeight.HasValue)
+            {
+                <tfoot>
+                    <tr class="table-secondary fw-bold">
+                        <td colspan="3" class="text-end">Total weight</td>
+                        <td class="text-end">@totalWeight.Value.ToString("0.###") lbs</td>
+                    </tr>
+                </tfoot>
+            }
+        </table>
+    </div>
+
+    <div class="mb-4">
+        <h2 class="h5">Shipping Estimate</h2>
+        @if (estimatedCost.HasValue)
+        {
+            <p class="fs-4">@estimatedCost.Value.ToString("C") <span class="text-muted fs-6">(@currency)</span></p>
+        }
+    </div>
+
+    <div class="d-flex gap-2">
+        <button type="button" class="btn btn-secondary" @onclick="HandleBack">Back</button>
+        <button type="button" class="btn btn-outline-secondary" @onclick="HandleSaveForLater">Save for later</button>
+        <button type="button" class="btn btn-primary" @onclick="HandleSubmitOrder">Submit order</button>
+    </div>
+}
+
+@code {
+    [Parameter]
+    public int OrderId { get; set; }
+
+    private bool isLoading = true;
+    private bool isRetrying;
+    private string? loadError;
+    private decimal? estimatedCost;
+    private string? currency;
+    private decimal? totalWeight;
+    private List<ItemDisplayModel> displayItems = [];
+
+    private record ItemDisplayModel(
+        int WidgetId,
+        string? Name,
+        int Quantity,
+        decimal? WeightPerUnit,
+        decimal? SubtotalWeight);
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (OrderId <= 0)
+        {
+            NavigationManager.NavigateTo("/orders/new");
+            return;
+        }
+
+        await LoadPageAsync();
+    }
+
+    private async Task LoadPageAsync()
+    {
+        isLoading = true;
+        loadError = null;
+
+        var draftResult = await Step3Service.GetDraftOrderAsync(OrderId);
+
+        switch (draftResult)
+        {
+            case GetDraftOrderResult.NotFound:
+            case GetDraftOrderResult.Forbidden:
+                NavigationManager.NavigateTo("/orders/new");
+                return;
+            case GetDraftOrderResult.Failure:
+                loadError = "Unable to load order. Please try again.";
+                isLoading = false;
+                return;
+        }
+
+        var order = ((GetDraftOrderResult.Success)draftResult).Order;
+
+        if (order.ShippingAddress is null)
+        {
+            NavigationManager.NavigateTo($"/orders/{OrderId}/address");
+            return;
+        }
+
+        BuildDisplayItems(order);
+
+        await CalculateShippingAsync();
+    }
+
+    private async Task RetryAsync()
+    {
+        isRetrying = true;
+        loadError = null;
+        await CalculateShippingAsync();
+        isRetrying = false;
+    }
+
+    private async Task CalculateShippingAsync()
+    {
+        isLoading = true;
+
+        var result = await Step3Service.CalculateShippingAsync(OrderId);
+
+        switch (result)
+        {
+            case CalculateShippingResult.Success success:
+                estimatedCost = success.EstimatedCost;
+                currency = success.Currency;
+                loadError = null;
+                break;
+            case CalculateShippingResult.NotFound:
+            case CalculateShippingResult.Forbidden:
+                NavigationManager.NavigateTo("/orders/new");
+                return;
+            case CalculateShippingResult.NoShippingAddress:
+                NavigationManager.NavigateTo($"/orders/{OrderId}/address");
+                return;
+            case CalculateShippingResult.ApiFailure:
+                loadError = "The shipping carrier is temporarily unavailable. Please retry or try again later.";
+                break;
+            default:
+                loadError = "An unexpected error occurred calculating shipping. Please try again.";
+                break;
+        }
+
+        isLoading = false;
+    }
+
+    private void BuildDisplayItems(GetDraftOrderResponse order)
+    {
+        var wizardItems = WizardState.OrderId == OrderId
+            ? WizardState.SelectedItems.ToDictionary(i => i.WidgetId)
+            : null;
+
+        displayItems = order.Items.Select(item =>
+        {
+            if (wizardItems is not null && wizardItems.TryGetValue(item.WidgetId, out var wi))
+            {
+                return new ItemDisplayModel(
+                    item.WidgetId,
+                    wi.Name,
+                    item.Quantity,
+                    wi.Weight,
+                    item.Quantity * wi.Weight);
+            }
+
+            return new ItemDisplayModel(item.WidgetId, null, item.Quantity, null, null);
+        }).ToList();
+
+        totalWeight = displayItems.All(i => i.SubtotalWeight.HasValue)
+            ? displayItems.Sum(i => i.SubtotalWeight!.Value)
+            : null;
+    }
+
+    private void HandleBack()
+    {
+        NavigationManager.NavigateTo($"/orders/{OrderId}/address");
+    }
+
+    private void HandleSaveForLater()
+    {
+        NavigationManager.NavigateTo("/orders");
+    }
+
+    private void HandleSubmitOrder()
+    {
+        NavigationManager.NavigateTo($"/orders/{OrderId}/submit");
+    }
+}

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step3/Step3Service.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step3/Step3Service.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace WidgetDepot.Web.Features.Orders.Create.Step3;
+
+public class Step3Service
+{
+    private readonly HttpClient _httpClient;
+
+    public Step3Service(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<GetDraftOrderResult> GetDraftOrderAsync(int orderId, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync($"/orders/{orderId}/draft", cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var order = await response.Content.ReadFromJsonAsync<GetDraftOrderResponse>(cancellationToken);
+            return order is null
+                ? new GetDraftOrderResult.Failure()
+                : new GetDraftOrderResult.Success(order);
+        }
+
+        return response.StatusCode switch
+        {
+            HttpStatusCode.NotFound => new GetDraftOrderResult.NotFound(),
+            HttpStatusCode.Forbidden => new GetDraftOrderResult.Forbidden(),
+            _ => new GetDraftOrderResult.Failure()
+        };
+    }
+
+    public async Task<CalculateShippingResult> CalculateShippingAsync(int orderId, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.PostAsync($"/orders/{orderId}/shipping-estimate", null, cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var result = await response.Content.ReadFromJsonAsync<CalculateShippingResponse>(cancellationToken);
+            return result is null
+                ? new CalculateShippingResult.Failure()
+                : new CalculateShippingResult.Success(result.EstimatedCost, result.Currency);
+        }
+
+        return response.StatusCode switch
+        {
+            HttpStatusCode.NotFound => new CalculateShippingResult.NotFound(),
+            HttpStatusCode.Forbidden => new CalculateShippingResult.Forbidden(),
+            HttpStatusCode.UnprocessableEntity => new CalculateShippingResult.NoShippingAddress(),
+            HttpStatusCode.BadGateway => new CalculateShippingResult.ApiFailure(),
+            _ => new CalculateShippingResult.Failure()
+        };
+    }
+}

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -14,6 +14,7 @@ using WidgetDepot.Web.Features.Catalog;
 using WidgetDepot.Web.Features.Orders.Create;
 using WidgetDepot.Web.Features.Orders.Create.Step1;
 using WidgetDepot.Web.Features.Orders.Create.Step2;
+using WidgetDepot.Web.Features.Orders.Create.Step3;
 using WidgetDepot.Web.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -63,6 +64,10 @@ builder.Services.AddHttpClient<Step1Service>(client =>
     .AddHttpMessageHandler<CookieForwardingHandler>();
 
 builder.Services.AddHttpClient<Step2Service>(client =>
+    client.BaseAddress = new Uri("https+http://apiservice"))
+    .AddHttpMessageHandler<CookieForwardingHandler>();
+
+builder.Services.AddHttpClient<Step3Service>(client =>
     client.BaseAddress = new Uri("https+http://apiservice"))
     .AddHttpMessageHandler<CookieForwardingHandler>();
 

--- a/tests/WidgetDepot.Tests/Features/Orders/Create/Step3/Step3ServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/Create/Step3/Step3ServiceTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Text;
+
+using Shouldly;
+
+using WidgetDepot.Web.Features.Orders.Create.Step3;
+
+namespace WidgetDepot.Tests.Features.Orders.Create.Step3;
+
+public class Step3ServiceTests
+{
+    private static Step3Service CreateService(HttpStatusCode statusCode, string? responseContent = null)
+    {
+        var handler = new FakeHttpMessageHandler(statusCode, responseContent: responseContent);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        return new Step3Service(httpClient);
+    }
+
+    [Fact]
+    public async Task GetDraftOrderAsync_OkResponse_ReturnsSuccessWithOrder()
+    {
+        var json = """{"id":5,"status":"Draft","items":[{"widgetId":1,"quantity":2}],"shippingAddress":{"recipientName":"Alice","streetLine1":"123 Main","streetLine2":null,"city":"Springfield","state":"IL","zipCode":"62701"},"billingAddress":null}""";
+        var service = CreateService(HttpStatusCode.OK, json);
+
+        var result = await service.GetDraftOrderAsync(5, TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetDraftOrderResult.Success>();
+        success.Order.Id.ShouldBe(5);
+        success.Order.Items.Count.ShouldBe(1);
+        success.Order.ShippingAddress.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task GetDraftOrderAsync_NotFoundResponse_ReturnsNotFound()
+    {
+        var service = CreateService(HttpStatusCode.NotFound);
+
+        var result = await service.GetDraftOrderAsync(999, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftOrderResult.NotFound>();
+    }
+
+    [Fact]
+    public async Task GetDraftOrderAsync_ForbiddenResponse_ReturnsForbidden()
+    {
+        var service = CreateService(HttpStatusCode.Forbidden);
+
+        var result = await service.GetDraftOrderAsync(5, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftOrderResult.Forbidden>();
+    }
+
+    [Fact]
+    public async Task GetDraftOrderAsync_ServerErrorResponse_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError);
+
+        var result = await service.GetDraftOrderAsync(5, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftOrderResult.Failure>();
+    }
+
+    [Fact]
+    public async Task CalculateShippingAsync_OkResponse_ReturnsSuccessWithCostAndCurrency()
+    {
+        var json = """{"estimatedCost":12.50,"currency":"USD"}""";
+        var service = CreateService(HttpStatusCode.OK, json);
+
+        var result = await service.CalculateShippingAsync(5, TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<CalculateShippingResult.Success>();
+        success.EstimatedCost.ShouldBe(12.50m);
+        success.Currency.ShouldBe("USD");
+    }
+
+    [Fact]
+    public async Task CalculateShippingAsync_NotFoundResponse_ReturnsNotFound()
+    {
+        var service = CreateService(HttpStatusCode.NotFound);
+
+        var result = await service.CalculateShippingAsync(999, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<CalculateShippingResult.NotFound>();
+    }
+
+    [Fact]
+    public async Task CalculateShippingAsync_ForbiddenResponse_ReturnsForbidden()
+    {
+        var service = CreateService(HttpStatusCode.Forbidden);
+
+        var result = await service.CalculateShippingAsync(5, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<CalculateShippingResult.Forbidden>();
+    }
+
+    [Fact]
+    public async Task CalculateShippingAsync_UnprocessableEntityResponse_ReturnsNoShippingAddress()
+    {
+        var service = CreateService(HttpStatusCode.UnprocessableEntity);
+
+        var result = await service.CalculateShippingAsync(5, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<CalculateShippingResult.NoShippingAddress>();
+    }
+
+    [Fact]
+    public async Task CalculateShippingAsync_BadGatewayResponse_ReturnsApiFailure()
+    {
+        var service = CreateService(HttpStatusCode.BadGateway);
+
+        var result = await service.CalculateShippingAsync(5, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<CalculateShippingResult.ApiFailure>();
+    }
+
+    [Fact]
+    public async Task CalculateShippingAsync_ServerErrorResponse_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError);
+
+        var result = await service.CalculateShippingAsync(5, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<CalculateShippingResult.Failure>();
+    }
+
+    private class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly string _responseContent;
+
+        public FakeHttpMessageHandler(HttpStatusCode statusCode, string? responseContent = null)
+        {
+            _statusCode = statusCode;
+            _responseContent = responseContent ?? "{}";
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_responseContent, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Step3Page.razor` at `/orders/{orderId}/shipping` with full shipping estimate display
- `Step3Service` calls `GET /orders/{orderId}/draft` (to validate addresses) and `POST /orders/{orderId}/shipping-estimate` (always fresh on arrival)
- Widget table shows name, quantity, weight per unit, and subtotal weight from wizard state; falls back to widget ID + quantity if navigating directly via URL
- Error state with Retry button when the shipping carrier API fails (502); wizard does not advance on failure
- Back → step 2, Save for later → `/orders` (stub), Submit order → `/orders/{orderId}/submit` (stub)
- 10 new unit tests in `Step3ServiceTests` covering all `GetDraftOrderAsync` and `CalculateShippingAsync` response variants

## Test plan

- [ ] Navigate the full wizard (step 1 → 2 → 3) and verify the widget table, weights, and shipping cost display correctly
- [ ] Confirm Back returns to step 2 with addresses preserved
- [ ] Confirm navigating directly to `/orders/{id}/shipping` without completing step 2 redirects to step 2
- [ ] Simulate a shipping API failure (BadGateway) and verify the error message and Retry button appear
- [ ] Verify `dotnet test` passes (128 passing, 1 skipped)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)