### PR TITLE
feat: implement DeleteDraft API endpoint for authenticated customer's draft orders

### DIFF
--- a/src/WidgetDepot.ApiService/Features/Orders/DeleteDraft/DeleteDraftEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/DeleteDraft/DeleteDraftEndpoint.cs
@@ -1,0 +1,33 @@
+using System.Security.Claims;
+
+namespace WidgetDepot.ApiService.Features.Orders.DeleteDraft;
+
+public static class DeleteDraftEndpoint
+{
+    public static IEndpointRouteBuilder MapDeleteDraft(this IEndpointRouteBuilder app)
+    {
+        app.MapDelete(OrderEndpoints.DeleteDraft, async (
+            int orderId,
+            ClaimsPrincipal user,
+            DeleteDraftHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            if (!user.TryGetCustomerId(out var customerId))
+                return Results.Unauthorized();
+
+            var error = await handler.HandleAsync(orderId, customerId, cancellationToken);
+
+            return error switch
+            {
+                DeleteDraftError.OrderNotFound => Results.NotFound(),
+                DeleteDraftError.Forbidden => Results.Forbid(),
+                null => Results.NoContent(),
+                _ => Results.Problem(statusCode: 500)
+            };
+        })
+        .WithName("DeleteDraft")
+        .RequireAuthorization();
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/DeleteDraft/DeleteDraftHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/DeleteDraft/DeleteDraftHandler.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Orders.DeleteDraft;
+
+public abstract record DeleteDraftError
+{
+    public record OrderNotFound : DeleteDraftError;
+    public record Forbidden : DeleteDraftError;
+}
+
+public class DeleteDraftHandler(AppDbContext db)
+{
+    public async Task<DeleteDraftError?> HandleAsync(int orderId, int customerId, CancellationToken cancellationToken)
+    {
+        var order = await db.Orders
+            .FirstOrDefaultAsync(o => o.Id == orderId, cancellationToken);
+
+        if (order is null)
+            return new DeleteDraftError.OrderNotFound();
+
+        if (order.CustomerId != customerId)
+            return new DeleteDraftError.Forbidden();
+
+        db.Orders.Remove(order);
+        await db.SaveChangesAsync(cancellationToken);
+
+        return null;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
@@ -1,5 +1,6 @@
 using WidgetDepot.ApiService.Features.Orders.CalculateShipping;
 using WidgetDepot.ApiService.Features.Orders.CreateDraft;
+using WidgetDepot.ApiService.Features.Orders.DeleteDraft;
 using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.GetDrafts;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
@@ -15,6 +16,7 @@ public static class OrderEndpointExtensions
         app.MapGetDrafts();
         app.MapSaveAddresses();
         app.MapCalculateShipping();
+        app.MapDeleteDraft();
 
         return app;
     }

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
@@ -9,4 +9,5 @@ public static class OrderEndpoints
     public const string GetDraftOrder = $"{Base}/{{orderId}}/draft";
     public const string CalculateShipping = $"{Base}/{{orderId}}/shipping-estimate";
     public const string GetDrafts = $"{Base}/drafts";
+    public const string DeleteDraft = $"{Base}/{{orderId}}/draft";
 }

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -9,6 +9,7 @@ using WidgetDepot.ApiService.Features.Accounts.Profile;
 using WidgetDepot.ApiService.Features.Accounts.Register;
 using WidgetDepot.ApiService.Features.Orders.CalculateShipping;
 using WidgetDepot.ApiService.Features.Orders.CreateDraft;
+using WidgetDepot.ApiService.Features.Orders.DeleteDraft;
 using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
 using WidgetDepot.ApiService.Features.Widgets.Import;
@@ -50,6 +51,7 @@ builder.Services.AddHttpClient<IShippingApiClient, AcmeShippingApiClient>(client
     client.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
 });
 builder.Services.AddScoped<CreateDraftOrderHandler>();
+builder.Services.AddScoped<DeleteDraftHandler>();
 builder.Services.AddScoped<GetDraftOrderHandler>();
 builder.Services.AddScoped<SaveAddressesHandler>();
 builder.Services.AddScoped<CalculateShippingHandler>();

--- a/tests/WidgetDepot.Tests/Features/Orders/DeleteDraft/DeleteDraftHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/DeleteDraft/DeleteDraftHandlerTests.cs
@@ -36,7 +36,7 @@ public class DeleteDraftHandlerTests
         using var db = CreateDb();
         var handler = new DeleteDraftHandler(db);
 
-        var result = await handler.HandleAsync(999, 1, TestContext.Current.CancellationToken);
+        var result = await handler.HandleAsync(999, customerId: 1, TestContext.Current.CancellationToken);
 
         result.ShouldBeOfType<DeleteDraftError.OrderNotFound>();
     }

--- a/tests/WidgetDepot.Tests/Features/Orders/DeleteDraft/DeleteDraftHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/DeleteDraft/DeleteDraftHandlerTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.EntityFrameworkCore;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.DeleteDraft;
+
+namespace WidgetDepot.Tests.Features.Orders.DeleteDraft;
+
+public class DeleteDraftHandlerTests
+{
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static async Task<Order> SeedOrderAsync(AppDbContext db, int customerId, OrderStatus status = OrderStatus.Draft)
+    {
+        var order = new Order
+        {
+            CustomerId = customerId,
+            Status = status,
+            CreatedAt = DateTime.UtcNow
+        };
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return order;
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderDoesNotExist_ReturnsOrderNotFoundError()
+    {
+        using var db = CreateDb();
+        var handler = new DeleteDraftHandler(db);
+
+        var result = await handler.HandleAsync(999, 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<DeleteDraftError.OrderNotFound>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderBelongsToOtherCustomer_ReturnsForbiddenError()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 2);
+        var handler = new DeleteDraftHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<DeleteDraftError.Forbidden>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidOrder_ReturnsNull()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1);
+        var handler = new DeleteDraftHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidOrder_DeletesOrder()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1);
+        var handler = new DeleteDraftHandler(db);
+
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var deleted = await db.Orders.FindAsync([order.Id], TestContext.Current.CancellationToken);
+        deleted.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderBelongsToOtherCustomer_DoesNotDeleteOrder()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 2);
+        var handler = new DeleteDraftHandler(db);
+
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var existing = await db.Orders.FindAsync([order.Id], TestContext.Current.CancellationToken);
+        existing.ShouldNotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `DELETE orders/{orderId}/draft` endpoint under `Features/Orders/DeleteDraft/`
- Returns 204 No Content on success, 404 if order not found, 403 if order belongs to another customer, 401 if unauthenticated
- Registers `DeleteDraftHandler` in DI and wires up the endpoint in `OrderEndpointExtensions`
- 5 unit tests covering: order not found, forbidden, successful deletion, order not deleted on forbidden

## Test plan
- [x] All 5 `DeleteDraftHandlerTests` pass (`dotnet test`)
- [x] Build succeeds with no warnings

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)