### PR TITLE
feat: implement draft orders list page at /orders

### DIFF
--- a/src/WidgetDepot.Web/Features/Orders/List/ListModels.cs
+++ b/src/WidgetDepot.Web/Features/Orders/List/ListModels.cs
@@ -1,0 +1,19 @@
+namespace WidgetDepot.Web.Features.Orders.List;
+
+public record DraftOrderListItem(int Id, int WidgetCount, DateTime CreatedAt, DateTime ExpiryDate);
+
+public abstract record GetDraftsResult
+{
+    public record Success(IReadOnlyList<DraftOrderListItem> Drafts) : GetDraftsResult;
+    public record Failure : GetDraftsResult;
+}
+
+public abstract record DeleteDraftResult
+{
+    public record Success : DeleteDraftResult;
+    public record NotFound : DeleteDraftResult;
+    public record Forbidden : DeleteDraftResult;
+    public record Failure : DeleteDraftResult;
+}
+
+internal record GetDraftsResponse(int Id, int WidgetCount, DateTime CreatedAt);

--- a/src/WidgetDepot.Web/Features/Orders/List/ListPage.razor
+++ b/src/WidgetDepot.Web/Features/Orders/List/ListPage.razor
@@ -1,0 +1,159 @@
+@page "/orders"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
+@using WidgetDepot.Web.Features.Orders.List
+@inject ListService ListService
+@inject NavigationManager NavigationManager
+
+<PageTitle>My Draft Orders</PageTitle>
+
+<h1>My Draft Orders</h1>
+
+@if (isLoading)
+{
+    <p>Loading...</p>
+}
+else if (loadFailed)
+{
+    <div class="alert alert-danger">Unable to load your draft orders. Please try again later.</div>
+}
+else if (drafts.Count == 0)
+{
+    <p class="text-muted">You have no draft orders. <a href="/orders/new">Start a new order</a>.</p>
+}
+else
+{
+    @if (errorMessage is not null)
+    {
+        <div class="alert alert-danger">@errorMessage</div>
+    }
+
+    <table class="table table-sm table-hover">
+        <thead class="table-dark">
+            <tr>
+                <th>Order ID</th>
+                <th>Widgets</th>
+                <th>Created</th>
+                <th>Expires</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var draft in drafts)
+            {
+                <tr>
+                    <td>@draft.Id</td>
+                    <td>@draft.WidgetCount</td>
+                    <td>@draft.CreatedAt.ToString("d")</td>
+                    <td>@draft.ExpiryDate.ToString("d")</td>
+                    <td>
+                        @if (pendingDeleteId == draft.Id)
+                        {
+                            <span class="me-2">Delete this order?</span>
+                            <button class="btn btn-sm btn-danger me-1"
+                                    @onclick="() => ConfirmDeleteAsync(draft.Id)"
+                                    disabled="@isDeleting">
+                                @(isDeleting ? "Deleting..." : "Yes, Delete")
+                            </button>
+                            <button class="btn btn-sm btn-secondary"
+                                    @onclick="CancelDelete"
+                                    disabled="@isDeleting">
+                                Cancel
+                            </button>
+                        }
+                        else
+                        {
+                            <button class="btn btn-sm btn-primary me-1" @onclick="() => Resume(draft.Id)">
+                                Resume
+                            </button>
+                            <button class="btn btn-sm btn-outline-danger" @onclick="() => RequestDelete(draft.Id)">
+                                Delete
+                            </button>
+                        }
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    private IReadOnlyList<DraftOrderListItem> drafts = [];
+    private bool isLoading = true;
+    private bool loadFailed;
+    private int? pendingDeleteId;
+    private bool isDeleting;
+    private string? errorMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var result = await ListService.GetDraftsAsync();
+
+        switch (result)
+        {
+            case GetDraftsResult.Success success:
+                drafts = success.Drafts;
+                break;
+            default:
+                loadFailed = true;
+                break;
+        }
+
+        isLoading = false;
+    }
+
+    private void Resume(int orderId)
+    {
+        NavigationManager.NavigateTo($"/orders/{orderId}/step1");
+    }
+
+    private void RequestDelete(int orderId)
+    {
+        pendingDeleteId = orderId;
+        errorMessage = null;
+    }
+
+    private void CancelDelete()
+    {
+        pendingDeleteId = null;
+    }
+
+    private async Task ConfirmDeleteAsync(int orderId)
+    {
+        isDeleting = true;
+        errorMessage = null;
+
+        try
+        {
+            var result = await ListService.DeleteDraftAsync(orderId);
+
+            switch (result)
+            {
+                case DeleteDraftResult.Success:
+                    drafts = drafts.Where(d => d.Id != orderId).ToList();
+                    pendingDeleteId = null;
+                    break;
+                case DeleteDraftResult.NotFound:
+                    errorMessage = "The order could not be found.";
+                    pendingDeleteId = null;
+                    break;
+                case DeleteDraftResult.Forbidden:
+                    errorMessage = "You do not have permission to delete this order.";
+                    pendingDeleteId = null;
+                    break;
+                default:
+                    errorMessage = "An unexpected error occurred. Please try again.";
+                    break;
+            }
+        }
+        catch (Exception)
+        {
+            errorMessage = "An unexpected error occurred. Please try again.";
+        }
+        finally
+        {
+            isDeleting = false;
+        }
+    }
+}

--- a/src/WidgetDepot.Web/Features/Orders/List/ListService.cs
+++ b/src/WidgetDepot.Web/Features/Orders/List/ListService.cs
@@ -1,0 +1,47 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace WidgetDepot.Web.Features.Orders.List;
+
+public class ListService
+{
+    private readonly HttpClient _httpClient;
+
+    public ListService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<GetDraftsResult> GetDraftsAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync("/orders/drafts", cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var drafts = await response.Content.ReadFromJsonAsync<List<GetDraftsResponse>>(cancellationToken);
+            if (drafts is null)
+                return new GetDraftsResult.Failure();
+
+            var items = drafts
+                .Select(d => new DraftOrderListItem(d.Id, d.WidgetCount, d.CreatedAt, d.CreatedAt.AddDays(30)))
+                .ToList();
+
+            return new GetDraftsResult.Success(items);
+        }
+
+        return new GetDraftsResult.Failure();
+    }
+
+    public async Task<DeleteDraftResult> DeleteDraftAsync(int orderId, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.DeleteAsync($"/orders/{orderId}/draft", cancellationToken);
+
+        return response.StatusCode switch
+        {
+            HttpStatusCode.NoContent => new DeleteDraftResult.Success(),
+            HttpStatusCode.NotFound => new DeleteDraftResult.NotFound(),
+            HttpStatusCode.Forbidden => new DeleteDraftResult.Forbidden(),
+            _ => new DeleteDraftResult.Failure()
+        };
+    }
+}

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -15,6 +15,7 @@ using WidgetDepot.Web.Features.Orders.Create;
 using WidgetDepot.Web.Features.Orders.Create.Step1;
 using WidgetDepot.Web.Features.Orders.Create.Step2;
 using WidgetDepot.Web.Features.Orders.Create.Step3;
+using WidgetDepot.Web.Features.Orders.List;
 using WidgetDepot.Web.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -68,6 +69,10 @@ builder.Services.AddHttpClient<Step2Service>(client =>
     .AddHttpMessageHandler<CookieForwardingHandler>();
 
 builder.Services.AddHttpClient<Step3Service>(client =>
+    client.BaseAddress = new Uri("https+http://apiservice"))
+    .AddHttpMessageHandler<CookieForwardingHandler>();
+
+builder.Services.AddHttpClient<ListService>(client =>
     client.BaseAddress = new Uri("https+http://apiservice"))
     .AddHttpMessageHandler<CookieForwardingHandler>();
 

--- a/tests/WidgetDepot.Tests/Features/Orders/List/ListServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/List/ListServiceTests.cs
@@ -1,0 +1,126 @@
+using System.Text;
+
+using Shouldly;
+
+using WidgetDepot.Web.Features.Orders.List;
+
+namespace WidgetDepot.Tests.Features.Orders.List;
+
+public class ListServiceTests
+{
+    private static ListService CreateService(HttpStatusCode statusCode, string responseBody)
+    {
+        var handler = new FakeHttpMessageHandler(statusCode, responseBody);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        return new ListService(httpClient);
+    }
+
+    [Fact]
+    public async Task GetDraftsAsync_SuccessResponse_ReturnsDrafts()
+    {
+        var body = """[{"id":1,"widgetCount":3,"createdAt":"2026-04-01T00:00:00"}]""";
+        var service = CreateService(HttpStatusCode.OK, body);
+
+        var result = await service.GetDraftsAsync(TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetDraftsResult.Success>();
+        success.Drafts.Count.ShouldBe(1);
+        success.Drafts[0].Id.ShouldBe(1);
+        success.Drafts[0].WidgetCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task GetDraftsAsync_SuccessResponse_SetsExpiryDateTo30DaysAfterCreated()
+    {
+        var body = """[{"id":1,"widgetCount":2,"createdAt":"2026-04-01T00:00:00"}]""";
+        var service = CreateService(HttpStatusCode.OK, body);
+
+        var result = await service.GetDraftsAsync(TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetDraftsResult.Success>();
+        success.Drafts[0].ExpiryDate.ShouldBe(new DateTime(2026, 5, 1));
+    }
+
+    [Fact]
+    public async Task GetDraftsAsync_EmptyResponse_ReturnsEmptyList()
+    {
+        var service = CreateService(HttpStatusCode.OK, "[]");
+
+        var result = await service.GetDraftsAsync(TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetDraftsResult.Success>();
+        success.Drafts.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetDraftsAsync_ServerError_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError, "{}");
+
+        var result = await service.GetDraftsAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftsResult.Failure>();
+    }
+
+    [Fact]
+    public async Task GetDraftsAsync_Unauthorized_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.Unauthorized, "{}");
+
+        var result = await service.GetDraftsAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftsResult.Failure>();
+    }
+
+    [Fact]
+    public async Task DeleteDraftAsync_SuccessResponse_ReturnsSuccess()
+    {
+        var service = CreateService(HttpStatusCode.NoContent, "");
+
+        var result = await service.DeleteDraftAsync(1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<DeleteDraftResult.Success>();
+    }
+
+    [Fact]
+    public async Task DeleteDraftAsync_NotFound_ReturnsNotFound()
+    {
+        var service = CreateService(HttpStatusCode.NotFound, "{}");
+
+        var result = await service.DeleteDraftAsync(1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<DeleteDraftResult.NotFound>();
+    }
+
+    [Fact]
+    public async Task DeleteDraftAsync_Forbidden_ReturnsForbidden()
+    {
+        var service = CreateService(HttpStatusCode.Forbidden, "{}");
+
+        var result = await service.DeleteDraftAsync(1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<DeleteDraftResult.Forbidden>();
+    }
+
+    [Fact]
+    public async Task DeleteDraftAsync_ServerError_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError, "{}");
+
+        var result = await service.DeleteDraftAsync(1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<DeleteDraftResult.Failure>();
+    }
+
+    private class FakeHttpMessageHandler(HttpStatusCode statusCode, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds authenticated Blazor page at `/orders` listing the customer's in-progress draft orders
- Each row shows order ID, widget count, created date, and expiry date (created + 30 days)
- Resume navigates to `/orders/{orderId}/step1`; Delete uses inline soft confirmation before calling the API
- 9 unit tests covering `ListService.GetDraftsAsync` and `ListService.DeleteDraftAsync`

## Test plan

- [x] Unauthenticated visitor navigating to `/orders` is redirected to login
- [x] Authenticated customer with no drafts sees empty state message
- [x] Authenticated customer with drafts sees table with Order ID, Widgets, Created, Expires columns
- [x] Clicking Resume navigates to `/orders/{orderId}/step1`
- [x] Clicking Delete shows inline confirmation row with Yes/Cancel buttons
- [x] Clicking Cancel dismisses the confirmation without deleting
- [x] Clicking Yes, Delete removes the draft and it disappears from the list
- [x] All 9 `ListServiceTests` pass with `dotnet test`

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)