### PR TITLE
API: SubmitOrder endpoint, EF Core migration, and order file writer

### DIFF
--- a/docs/milestone-02/05-order-submission.md
+++ b/docs/milestone-02/05-order-submission.md
@@ -13,9 +13,9 @@ can submit the order. Submission changes the order status to `Submitted` and cau
 to write an order file to a designated pickup directory. A separate scheduled job (story in
 Milestone 3) transmits those files to the ERP system via FTP.
 
-**Dependency:** The ERP order file format is TBD — it must match the format used by the
-existing website. This story cannot be fully implemented until the format spec is confirmed.
-The story should be implementation-ready in all other respects.
+**Dependency:** The ERP order file format is described here:
+
+[ERP File Format](../standards/erp-order-format.md)
 
 ## Scope
 
@@ -35,9 +35,11 @@ The story should be implementation-ready in all other respects.
 
 - New feature slice: `WidgetDepot.Web/Features/Orders/Submit/`
 - New API endpoint: `WidgetDepot.ApiService/Features/Orders/Submit/`
+- Create an order file class (OrderFile) that uses the order, the addresses, and line items
+  and creates the contents of the file as a string. 
 - The order file writer should be implemented behind an interface (e.g., `IOrderFileWriter`) so it can be tested without touching the filesystem
 - The pickup directory path should be read from configuration (e.g., `Orders:PickupDirectory`)
-- Order file format must replicate the existing ERP format exactly (spec TBD — treat as a required input before implementation)
+- Order file format must replicate the existing ERP format exactly
 - Only orders with `Draft` status and all required fields populated (widgets, both addresses, shipping estimate) may be submitted; return a typed error otherwise
 - `SubmittedAt` timestamp should be added to the `Order` entity (nullable; set when status transitions to `Submitted`) — add an EF Core migration
 - Patterns to follow: Vertical Slice Architecture; EF Core for data access; Bootstrap 5.3 for layout; no MediatR

--- a/docs/standards/erp-order-format.md
+++ b/docs/standards/erp-order-format.md
@@ -1,0 +1,68 @@
+## ERP Order Format
+
+Each order is sent to the ERP using an order file transmitted via FTP. Here is the file format:
+
+## Naming Convention
+
+The file name is EXT-{OrderNum}.TXT. Where OrderNum is the primary key of the order, left-padded
+with zeros (10 characters in total). For example, the file name for order 42 is:
+
+`EXT-0000000042.TXT`
+
+## Line Separators
+
+Each line in the file is separated by a carriage return character and a line feed character (\r\n).
+
+## Fixed-Width Fields
+
+Each field uses a fixed-width format. The line descriptions define how many characters
+wide each field is, how the contents are aligned, and formatted.
+
+## Header 
+
+Each file starts with a header line:
+
+| Field | Width | Aligned | Format |
+| ----- | ----- | ------- | ----------- |
+| OrderNum | 10 | RIGHT | left-padded with zeros |
+| Email | 100 | LEFT | n/a |
+| DateSubmitted | 10 | LEFT | yyyy/MM/dd |
+| Total Weight | 10 | RIGHT | 0000000.00 |
+
+## Shipping Address
+
+The second line contains the shipping address:
+
+| Field | Width | Aligned | Format |
+| ----- | ----- | ------- | ----------- |
+| OrderNum | 10 | RIGHT | left-padded with zeros |
+| AddressType | 10 | LEFT | 'S' |
+| Street1 | 200 | LEFT | n/a |
+| Street2 | 200 | LEFT | n/a |
+| City | 100 | LEFT | n/a |
+| State | 2 | LEFT | n/a |
+| Zip | 10 | LEFT | n/a |
+
+## Billing Address
+
+The third line contains the shipping address:
+
+| Field | Width | Aligned | Format |
+| ----- | ----- | ------- | ----------- |
+| OrderNum | 10 | RIGHT | left-padded with zeros |
+| AddressType | 10 | LEFT | 'B' |
+| Street1 | 200 | LEFT | n/a |
+| Street2 | 200 | LEFT | n/a |
+| City | 100 | LEFT | n/a |
+| State | 2 | LEFT | n/a |
+| Zip | 10 | LEFT | n/a |
+
+## Line Item
+
+For each item in the order, add one line:
+
+| Field | Width | Aligned | Format |
+| ----- | ----- | ------- | ----------- |
+| OrderNum | 10 | RIGHT | left-padded with zeros |
+| WidgetID | 10 | RIGHT | left-padded with zeros |
+| Quantity | 10 | RIGHT | left-padded with zeros |

--- a/src/WidgetDepot.ApiService/Data/Migrations/20260510092045_AddOrderSubmittedAt.Designer.cs
+++ b/src/WidgetDepot.ApiService/Data/Migrations/20260510092045_AddOrderSubmittedAt.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WidgetDepot.ApiService.Data;
@@ -11,9 +12,11 @@ using WidgetDepot.ApiService.Data;
 namespace WidgetDepot.ApiService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510092045_AddOrderSubmittedAt")]
+    partial class AddOrderSubmittedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WidgetDepot.ApiService/Data/Migrations/20260510092045_AddOrderSubmittedAt.cs
+++ b/src/WidgetDepot.ApiService/Data/Migrations/20260510092045_AddOrderSubmittedAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WidgetDepot.ApiService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrderSubmittedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "SubmittedAt",
+                table: "Orders",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SubmittedAt",
+                table: "Orders");
+        }
+    }
+}

--- a/src/WidgetDepot.ApiService/Data/Order.cs
+++ b/src/WidgetDepot.ApiService/Data/Order.cs
@@ -17,4 +17,5 @@ public class Order
     public Address? ShippingAddress { get; set; }
     public Address? BillingAddress { get; set; }
     public decimal? ShippingEstimate { get; set; }
+    public DateTime? SubmittedAt { get; set; }
 }

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
@@ -4,6 +4,7 @@ using WidgetDepot.ApiService.Features.Orders.DeleteDraft;
 using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.GetDrafts;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
+using WidgetDepot.ApiService.Features.Orders.Submit;
 
 namespace WidgetDepot.ApiService.Features.Orders;
 
@@ -17,6 +18,7 @@ public static class OrderEndpointExtensions
         app.MapSaveAddresses();
         app.MapCalculateShipping();
         app.MapDeleteDraft();
+        app.MapSubmitOrder();
 
         return app;
     }

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
@@ -10,4 +10,5 @@ public static class OrderEndpoints
     public const string CalculateShipping = $"{Base}/{{orderId}}/shipping-estimate";
     public const string GetDrafts = $"{Base}/drafts";
     public const string DeleteDraft = $"{Base}/{{orderId}}/draft";
+    public const string SubmitOrder = $"{Base}/{{orderId}}/submit";
 }

--- a/src/WidgetDepot.ApiService/Features/Orders/Submit/IOrderFileWriter.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/Submit/IOrderFileWriter.cs
@@ -1,0 +1,6 @@
+namespace WidgetDepot.ApiService.Features.Orders.Submit;
+
+public interface IOrderFileWriter
+{
+    Task WriteAsync(OrderFile orderFile, CancellationToken cancellationToken);
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/Submit/OrderFile.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/Submit/OrderFile.cs
@@ -6,14 +6,19 @@ namespace WidgetDepot.ApiService.Features.Orders.Submit;
 
 public class OrderFile
 {
+    private readonly Order _order;
+    private readonly string _customerEmail;
+
     public string FileName { get; }
-    public string Content { get; }
 
     public OrderFile(Order order, string customerEmail)
     {
         FileName = $"EXT-{order.Id.ToString().PadLeft(10, '0')}.TXT";
-        Content = BuildContent(order, customerEmail);
+        _order = order;
+        _customerEmail = customerEmail;
     }
+
+    public string GetContent() => BuildContent(_order, _customerEmail);
 
     private static string BuildContent(Order order, string customerEmail)
     {

--- a/src/WidgetDepot.ApiService/Features/Orders/Submit/OrderFile.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/Submit/OrderFile.cs
@@ -1,0 +1,62 @@
+using System.Text;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Orders.Submit;
+
+public class OrderFile
+{
+    public string FileName { get; }
+    public string Content { get; }
+
+    public OrderFile(Order order, string customerEmail)
+    {
+        FileName = $"EXT-{order.Id.ToString().PadLeft(10, '0')}.TXT";
+        Content = BuildContent(order, customerEmail);
+    }
+
+    private static string BuildContent(Order order, string customerEmail)
+    {
+        var sb = new StringBuilder();
+
+        var totalWeight = order.Items.Sum(i => i.Quantity * i.Widget.Weight);
+        var dateSubmitted = (order.SubmittedAt ?? DateTime.UtcNow).ToString("yyyy/MM/dd");
+
+        sb.Append(ZeroPad(order.Id.ToString(), 10));
+        sb.Append(PadRight(customerEmail, 100));
+        sb.Append(PadRight(dateSubmitted, 10));
+        sb.Append(totalWeight.ToString("0000000.00"));
+        sb.Append("\r\n");
+
+        AppendAddress(sb, order.Id, "S", order.ShippingAddress!);
+        AppendAddress(sb, order.Id, "B", order.BillingAddress!);
+
+        foreach (var item in order.Items)
+        {
+            sb.Append(ZeroPad(order.Id.ToString(), 10));
+            sb.Append(ZeroPad(item.WidgetId.ToString(), 10));
+            sb.Append(ZeroPad(item.Quantity.ToString(), 10));
+            sb.Append("\r\n");
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendAddress(StringBuilder sb, int orderId, string addressType, Address address)
+    {
+        sb.Append(ZeroPad(orderId.ToString(), 10));
+        sb.Append(PadRight(addressType, 10));
+        sb.Append(PadRight(address.StreetLine1, 200));
+        sb.Append(PadRight(address.StreetLine2 ?? "", 200));
+        sb.Append(PadRight(address.City, 100));
+        sb.Append(PadRight(address.State, 2));
+        sb.Append(PadRight(address.ZipCode, 10));
+        sb.Append("\r\n");
+    }
+
+    private static string PadRight(string value, int width) =>
+        value.PadRight(width)[..width];
+
+    private static string ZeroPad(string value, int width) =>
+        value.PadLeft(width, '0')[^width..];
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/Submit/OrderFileWriter.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/Submit/OrderFileWriter.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Configuration;
+
+namespace WidgetDepot.ApiService.Features.Orders.Submit;
+
+public class OrderFileWriter : IOrderFileWriter
+{
+    private readonly string _pickupDirectory;
+
+    public OrderFileWriter(IConfiguration configuration)
+    {
+        _pickupDirectory = configuration["Orders:PickupDirectory"] ?? "";
+    }
+
+    public async Task WriteAsync(OrderFile orderFile, CancellationToken cancellationToken)
+    {
+        var filePath = Path.Combine(_pickupDirectory, orderFile.FileName);
+        await File.WriteAllTextAsync(filePath, orderFile.Content, cancellationToken);
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/Submit/OrderFileWriter.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/Submit/OrderFileWriter.cs
@@ -14,6 +14,6 @@ public class OrderFileWriter : IOrderFileWriter
     public async Task WriteAsync(OrderFile orderFile, CancellationToken cancellationToken)
     {
         var filePath = Path.Combine(_pickupDirectory, orderFile.FileName);
-        await File.WriteAllTextAsync(filePath, orderFile.Content, cancellationToken);
+        await File.WriteAllTextAsync(filePath, orderFile.GetContent(), cancellationToken);
     }
 }

--- a/src/WidgetDepot.ApiService/Features/Orders/Submit/SubmitOrderEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/Submit/SubmitOrderEndpoint.cs
@@ -1,0 +1,35 @@
+using System.Security.Claims;
+
+namespace WidgetDepot.ApiService.Features.Orders.Submit;
+
+public static class SubmitOrderEndpoint
+{
+    public static IEndpointRouteBuilder MapSubmitOrder(this IEndpointRouteBuilder app)
+    {
+        app.MapPost(OrderEndpoints.SubmitOrder, async (
+            int orderId,
+            ClaimsPrincipal user,
+            SubmitOrderHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            if (!user.TryGetCustomerId(out var customerId))
+                return Results.Unauthorized();
+
+            var result = await handler.HandleAsync(orderId, customerId, cancellationToken);
+
+            return result switch
+            {
+                SubmitOrderError.OrderNotFound => Results.NotFound(),
+                SubmitOrderError.Forbidden => Results.Forbid(),
+                SubmitOrderError.InvalidOrderState => Results.Conflict(),
+                SubmitOrderError.IncompleteOrder error => Results.Problem(detail: error.Reason, statusCode: 422),
+                SubmitOrderResponse response => Results.Ok(response),
+                _ => Results.Problem(statusCode: 500)
+            };
+        })
+        .WithName("SubmitOrder")
+        .RequireAuthorization();
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/Submit/SubmitOrderHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/Submit/SubmitOrderHandler.cs
@@ -1,0 +1,70 @@
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Orders.Submit;
+
+public record SubmitOrderResponse(int OrderId);
+
+public abstract record SubmitOrderError
+{
+    public record OrderNotFound : SubmitOrderError;
+    public record Forbidden : SubmitOrderError;
+    public record InvalidOrderState : SubmitOrderError;
+    public record IncompleteOrder(string Reason) : SubmitOrderError;
+}
+
+public class SubmitOrderHandler
+{
+    private readonly AppDbContext _db;
+    private readonly IOrderFileWriter _orderFileWriter;
+
+    public SubmitOrderHandler(AppDbContext db, IOrderFileWriter orderFileWriter)
+    {
+        _db = db;
+        _orderFileWriter = orderFileWriter;
+    }
+
+    public async Task<object> HandleAsync(int orderId, int customerId, CancellationToken cancellationToken)
+    {
+        var order = await _db.Orders
+            .Include(o => o.Items)
+                .ThenInclude(i => i.Widget)
+            .FirstOrDefaultAsync(o => o.Id == orderId, cancellationToken);
+
+        if (order is null)
+            return new SubmitOrderError.OrderNotFound();
+
+        if (order.CustomerId != customerId)
+            return new SubmitOrderError.Forbidden();
+
+        if (order.Status != OrderStatus.Draft)
+            return new SubmitOrderError.InvalidOrderState();
+
+        if (!order.Items.Any())
+            return new SubmitOrderError.IncompleteOrder("Order has no items.");
+
+        if (order.ShippingAddress is null)
+            return new SubmitOrderError.IncompleteOrder("Shipping address is missing.");
+
+        if (order.BillingAddress is null)
+            return new SubmitOrderError.IncompleteOrder("Billing address is missing.");
+
+        if (order.ShippingEstimate is null)
+            return new SubmitOrderError.IncompleteOrder("Shipping estimate is missing.");
+
+        var customer = await _db.Customers.FindAsync([customerId], cancellationToken);
+        if (customer is null)
+            return new SubmitOrderError.OrderNotFound();
+
+        order.Status = OrderStatus.Submitted;
+        order.SubmittedAt = DateTime.UtcNow;
+
+        var orderFile = new OrderFile(order, customer.Email);
+        await _orderFileWriter.WriteAsync(orderFile, cancellationToken);
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return new SubmitOrderResponse(order.Id);
+    }
+}

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -58,14 +58,14 @@ builder.Services.AddScoped<GetDraftOrderHandler>();
 builder.Services.AddScoped<GetDraftsHandler>();
 builder.Services.AddScoped<SaveAddressesHandler>();
 builder.Services.AddScoped<CalculateShippingHandler>();
-builder.Services.AddScoped<SubmitOrderHandler>();
-builder.Services.AddScoped<IOrderFileWriter, OrderFileWriter>();
 builder.Services.AddScoped<SearchWidgetsHandler>();
 builder.Services.AddScoped<ImportWidgetsCsvHandler>();
 builder.Services.AddScoped<RegisterHandler>();
 builder.Services.AddScoped<LoginHandler>();
 builder.Services.AddScoped<ProfileHandler>();
 builder.Services.AddScoped<PasswordChangeHandler>();
+builder.Services.AddScoped<SubmitOrderHandler>();
+builder.Services.AddScoped<IOrderFileWriter, OrderFileWriter>();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -13,6 +13,7 @@ using WidgetDepot.ApiService.Features.Orders.DeleteDraft;
 using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.GetDrafts;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
+using WidgetDepot.ApiService.Features.Orders.Submit;
 using WidgetDepot.ApiService.Features.Widgets.Import;
 using WidgetDepot.ApiService.Features.Widgets.Search;
 
@@ -57,6 +58,8 @@ builder.Services.AddScoped<GetDraftOrderHandler>();
 builder.Services.AddScoped<GetDraftsHandler>();
 builder.Services.AddScoped<SaveAddressesHandler>();
 builder.Services.AddScoped<CalculateShippingHandler>();
+builder.Services.AddScoped<SubmitOrderHandler>();
+builder.Services.AddScoped<IOrderFileWriter, OrderFileWriter>();
 builder.Services.AddScoped<SearchWidgetsHandler>();
 builder.Services.AddScoped<ImportWidgetsCsvHandler>();
 builder.Services.AddScoped<RegisterHandler>();

--- a/tests/WidgetDepot.Tests/Features/Orders/Submit/OrderFileTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/Submit/OrderFileTests.cs
@@ -58,7 +58,7 @@ public class OrderFileTests
 
         var file = new OrderFile(order, "alice@example.com");
 
-        var header = GetLine(file.Content, 0);
+        var header = GetLine(file.GetContent(), 0);
         header[..10].ShouldBe("0000000042");
     }
 
@@ -69,7 +69,7 @@ public class OrderFileTests
 
         var file = new OrderFile(order, "alice@example.com");
 
-        var header = GetLine(file.Content, 0);
+        var header = GetLine(file.GetContent(), 0);
         header.Substring(10, 100).TrimEnd().ShouldBe("alice@example.com");
     }
 
@@ -80,7 +80,7 @@ public class OrderFileTests
 
         var file = new OrderFile(order, "alice@example.com");
 
-        var header = GetLine(file.Content, 0);
+        var header = GetLine(file.GetContent(), 0);
         header.Substring(110, 10).TrimEnd().ShouldBe("2026/05/10");
     }
 
@@ -92,7 +92,7 @@ public class OrderFileTests
         var file = new OrderFile(order, "alice@example.com");
 
         // 3 items × 2.5 weight = 7.5 total
-        var header = GetLine(file.Content, 0);
+        var header = GetLine(file.GetContent(), 0);
         header.Substring(120, 10).ShouldBe("0000007.50");
     }
 
@@ -103,7 +103,7 @@ public class OrderFileTests
 
         var file = new OrderFile(order, "alice@example.com");
 
-        var line = GetLine(file.Content, 1);
+        var line = GetLine(file.GetContent(), 1);
         line.Substring(10, 10).TrimEnd().ShouldBe("S");
     }
 
@@ -114,7 +114,7 @@ public class OrderFileTests
 
         var file = new OrderFile(order, "alice@example.com");
 
-        var line = GetLine(file.Content, 2);
+        var line = GetLine(file.GetContent(), 2);
         line.Substring(10, 10).TrimEnd().ShouldBe("B");
     }
 
@@ -125,7 +125,7 @@ public class OrderFileTests
 
         var file = new OrderFile(order, "alice@example.com");
 
-        var line = GetLine(file.Content, 3);
+        var line = GetLine(file.GetContent(), 3);
         line.Substring(10, 10).ShouldBe("0000000007");
     }
 
@@ -136,7 +136,7 @@ public class OrderFileTests
 
         var file = new OrderFile(order, "alice@example.com");
 
-        var line = GetLine(file.Content, 3);
+        var line = GetLine(file.GetContent(), 3);
         line.Substring(20, 10).ShouldBe("0000000003");
     }
 
@@ -149,7 +149,7 @@ public class OrderFileTests
 
         var file = new OrderFile(order, "alice@example.com");
 
-        var lines = file.Content.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+        var lines = file.GetContent().Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
         lines.Length.ShouldBe(5); // header + shipping + billing + 2 items
     }
 

--- a/tests/WidgetDepot.Tests/Features/Orders/Submit/OrderFileTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/Submit/OrderFileTests.cs
@@ -1,0 +1,158 @@
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.Submit;
+
+namespace WidgetDepot.Tests.Features.Orders.Submit;
+
+public class OrderFileTests
+{
+    private static Order BuildOrder(int orderId = 42)
+    {
+        var order = new Order
+        {
+            Id = orderId,
+            CustomerId = 1,
+            Status = OrderStatus.Submitted,
+            CreatedAt = DateTime.UtcNow,
+            SubmittedAt = new DateTime(2026, 5, 10, 12, 0, 0, DateTimeKind.Utc),
+            ShippingAddress = new Address
+            {
+                RecipientName = "Alice Smith",
+                StreetLine1 = "123 Main St",
+                StreetLine2 = "Apt 4",
+                City = "Springfield",
+                State = "IL",
+                ZipCode = "62701"
+            },
+            BillingAddress = new Address
+            {
+                RecipientName = "Alice Smith",
+                StreetLine1 = "456 Oak Ave",
+                City = "Shelbyville",
+                State = "IL",
+                ZipCode = "62565"
+            }
+        };
+
+        var widget = new Widget { Id = 7, Sku = "W-001", Name = "Sprocket", Weight = 2.5m };
+        order.Items.Add(new OrderItem { WidgetId = widget.Id, Widget = widget, Quantity = 3 });
+
+        return order;
+    }
+
+    [Fact]
+    public void FileName_IsZeroPaddedOrderId()
+    {
+        var order = BuildOrder(orderId: 42);
+
+        var file = new OrderFile(order, "alice@example.com");
+
+        file.FileName.ShouldBe("EXT-0000000042.TXT");
+    }
+
+    [Fact]
+    public void Content_HeaderLine_ContainsZeroPaddedOrderId()
+    {
+        var order = BuildOrder(orderId: 42);
+
+        var file = new OrderFile(order, "alice@example.com");
+
+        var header = GetLine(file.Content, 0);
+        header[..10].ShouldBe("0000000042");
+    }
+
+    [Fact]
+    public void Content_HeaderLine_ContainsCustomerEmail()
+    {
+        var order = BuildOrder();
+
+        var file = new OrderFile(order, "alice@example.com");
+
+        var header = GetLine(file.Content, 0);
+        header.Substring(10, 100).TrimEnd().ShouldBe("alice@example.com");
+    }
+
+    [Fact]
+    public void Content_HeaderLine_ContainsSubmittedAtDate()
+    {
+        var order = BuildOrder();
+
+        var file = new OrderFile(order, "alice@example.com");
+
+        var header = GetLine(file.Content, 0);
+        header.Substring(110, 10).TrimEnd().ShouldBe("2026/05/10");
+    }
+
+    [Fact]
+    public void Content_HeaderLine_ContainsTotalWeight()
+    {
+        var order = BuildOrder();
+
+        var file = new OrderFile(order, "alice@example.com");
+
+        // 3 items × 2.5 weight = 7.5 total
+        var header = GetLine(file.Content, 0);
+        header.Substring(120, 10).ShouldBe("0000007.50");
+    }
+
+    [Fact]
+    public void Content_ShippingAddressLine_HasAddressTypeS()
+    {
+        var order = BuildOrder();
+
+        var file = new OrderFile(order, "alice@example.com");
+
+        var line = GetLine(file.Content, 1);
+        line.Substring(10, 10).TrimEnd().ShouldBe("S");
+    }
+
+    [Fact]
+    public void Content_BillingAddressLine_HasAddressTypeB()
+    {
+        var order = BuildOrder();
+
+        var file = new OrderFile(order, "alice@example.com");
+
+        var line = GetLine(file.Content, 2);
+        line.Substring(10, 10).TrimEnd().ShouldBe("B");
+    }
+
+    [Fact]
+    public void Content_LineItem_ContainsZeroPaddedWidgetId()
+    {
+        var order = BuildOrder();
+
+        var file = new OrderFile(order, "alice@example.com");
+
+        var line = GetLine(file.Content, 3);
+        line.Substring(10, 10).ShouldBe("0000000007");
+    }
+
+    [Fact]
+    public void Content_LineItem_ContainsZeroPaddedQuantity()
+    {
+        var order = BuildOrder();
+
+        var file = new OrderFile(order, "alice@example.com");
+
+        var line = GetLine(file.Content, 3);
+        line.Substring(20, 10).ShouldBe("0000000003");
+    }
+
+    [Fact]
+    public void Content_HasOneLineItemPerOrderItem()
+    {
+        var order = BuildOrder();
+        var widget2 = new Widget { Id = 8, Sku = "W-002", Name = "Cog", Weight = 1.0m };
+        order.Items.Add(new OrderItem { WidgetId = widget2.Id, Widget = widget2, Quantity = 1 });
+
+        var file = new OrderFile(order, "alice@example.com");
+
+        var lines = file.Content.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+        lines.Length.ShouldBe(5); // header + shipping + billing + 2 items
+    }
+
+    private static string GetLine(string content, int index) =>
+        content.Split("\r\n")[index];
+}

--- a/tests/WidgetDepot.Tests/Features/Orders/Submit/SubmitOrderHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/Submit/SubmitOrderHandlerTests.cs
@@ -1,0 +1,272 @@
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.Submit;
+
+namespace WidgetDepot.Tests.Features.Orders.Submit;
+
+public class SubmitOrderHandlerTests
+{
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static SubmitOrderHandler CreateHandler(AppDbContext db, IOrderFileWriter? writer = null)
+    {
+        var mockWriter = writer ?? new Mock<IOrderFileWriter>().Object;
+        return new SubmitOrderHandler(db, mockWriter);
+    }
+
+    private static async Task<(Order order, Customer customer)> SeedFullOrderAsync(AppDbContext db, int customerId = 1)
+    {
+        var customer = new Customer
+        {
+            Id = customerId,
+            FirstName = "Alice",
+            LastName = "Smith",
+            Email = "alice@example.com",
+            PasswordHash = "hash",
+            CreatedAt = DateTime.UtcNow
+        };
+        db.Customers.Add(customer);
+
+        var widget = new Widget { Id = 1, Sku = "W-001", Name = "Sprocket", Weight = 2.0m };
+        db.Widgets.Add(widget);
+
+        var order = new Order
+        {
+            CustomerId = customerId,
+            Status = OrderStatus.Draft,
+            CreatedAt = DateTime.UtcNow,
+            ShippingAddress = new Address
+            {
+                RecipientName = "Alice Smith",
+                StreetLine1 = "123 Main St",
+                City = "Springfield",
+                State = "IL",
+                ZipCode = "62701"
+            },
+            BillingAddress = new Address
+            {
+                RecipientName = "Alice Smith",
+                StreetLine1 = "456 Oak Ave",
+                City = "Shelbyville",
+                State = "IL",
+                ZipCode = "62565"
+            },
+            ShippingEstimate = 12.99m
+        };
+        order.Items.Add(new OrderItem { WidgetId = widget.Id, Quantity = 2 });
+        db.Orders.Add(order);
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return (order, customer);
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderNotFound_ReturnsOrderNotFound()
+    {
+        using var db = CreateDb();
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(999, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitOrderError.OrderNotFound>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderBelongsToOtherCustomer_ReturnsForbidden()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedFullOrderAsync(db, customerId: 2);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitOrderError.Forbidden>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderAlreadySubmitted_ReturnsInvalidOrderState()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedFullOrderAsync(db);
+        order.Status = OrderStatus.Submitted;
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitOrderError.InvalidOrderState>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderHasNoItems_ReturnsIncompleteOrder()
+    {
+        using var db = CreateDb();
+        var customer = new Customer { Id = 1, FirstName = "A", LastName = "B", Email = "a@b.com", PasswordHash = "h", CreatedAt = DateTime.UtcNow };
+        db.Customers.Add(customer);
+        var order = new Order
+        {
+            CustomerId = 1,
+            Status = OrderStatus.Draft,
+            CreatedAt = DateTime.UtcNow,
+            ShippingAddress = new Address { RecipientName = "A", StreetLine1 = "1 St", City = "City", State = "IL", ZipCode = "12345" },
+            BillingAddress = new Address { RecipientName = "A", StreetLine1 = "1 St", City = "City", State = "IL", ZipCode = "12345" },
+            ShippingEstimate = 9.99m
+        };
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitOrderError.IncompleteOrder>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_MissingShippingAddress_ReturnsIncompleteOrder()
+    {
+        using var db = CreateDb();
+        var customer = new Customer { Id = 1, FirstName = "A", LastName = "B", Email = "a@b.com", PasswordHash = "h", CreatedAt = DateTime.UtcNow };
+        db.Customers.Add(customer);
+        var widget = new Widget { Id = 1, Sku = "W-001", Name = "W", Weight = 1m };
+        db.Widgets.Add(widget);
+        var order = new Order
+        {
+            CustomerId = 1,
+            Status = OrderStatus.Draft,
+            CreatedAt = DateTime.UtcNow,
+            BillingAddress = new Address { RecipientName = "A", StreetLine1 = "1 St", City = "City", State = "IL", ZipCode = "12345" },
+            ShippingEstimate = 9.99m
+        };
+        order.Items.Add(new OrderItem { WidgetId = widget.Id, Quantity = 1 });
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitOrderError.IncompleteOrder>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_MissingBillingAddress_ReturnsIncompleteOrder()
+    {
+        using var db = CreateDb();
+        var customer = new Customer { Id = 1, FirstName = "A", LastName = "B", Email = "a@b.com", PasswordHash = "h", CreatedAt = DateTime.UtcNow };
+        db.Customers.Add(customer);
+        var widget = new Widget { Id = 1, Sku = "W-001", Name = "W", Weight = 1m };
+        db.Widgets.Add(widget);
+        var order = new Order
+        {
+            CustomerId = 1,
+            Status = OrderStatus.Draft,
+            CreatedAt = DateTime.UtcNow,
+            ShippingAddress = new Address { RecipientName = "A", StreetLine1 = "1 St", City = "City", State = "IL", ZipCode = "12345" },
+            ShippingEstimate = 9.99m
+        };
+        order.Items.Add(new OrderItem { WidgetId = widget.Id, Quantity = 1 });
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitOrderError.IncompleteOrder>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_MissingShippingEstimate_ReturnsIncompleteOrder()
+    {
+        using var db = CreateDb();
+        var customer = new Customer { Id = 1, FirstName = "A", LastName = "B", Email = "a@b.com", PasswordHash = "h", CreatedAt = DateTime.UtcNow };
+        db.Customers.Add(customer);
+        var widget = new Widget { Id = 1, Sku = "W-001", Name = "W", Weight = 1m };
+        db.Widgets.Add(widget);
+        var order = new Order
+        {
+            CustomerId = 1,
+            Status = OrderStatus.Draft,
+            CreatedAt = DateTime.UtcNow,
+            ShippingAddress = new Address { RecipientName = "A", StreetLine1 = "1 St", City = "City", State = "IL", ZipCode = "12345" },
+            BillingAddress = new Address { RecipientName = "A", StreetLine1 = "1 St", City = "City", State = "IL", ZipCode = "12345" }
+        };
+        order.Items.Add(new OrderItem { WidgetId = widget.Id, Quantity = 1 });
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitOrderError.IncompleteOrder>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidOrder_ReturnsSubmitOrderResponse()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedFullOrderAsync(db);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<SubmitOrderResponse>();
+        response.OrderId.ShouldBe(order.Id);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidOrder_SetsOrderStatusToSubmitted()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedFullOrderAsync(db);
+        var handler = CreateHandler(db);
+
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.Status.ShouldBe(OrderStatus.Submitted);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidOrder_SetsSubmittedAt()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedFullOrderAsync(db);
+        var handler = CreateHandler(db);
+
+        var before = DateTime.UtcNow;
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+        var after = DateTime.UtcNow;
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.SubmittedAt.ShouldNotBeNull();
+        saved.SubmittedAt.Value.ShouldBeGreaterThanOrEqualTo(before);
+        saved.SubmittedAt.Value.ShouldBeLessThanOrEqualTo(after);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidOrder_CallsOrderFileWriter()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedFullOrderAsync(db);
+
+        var mockWriter = new Mock<IOrderFileWriter>();
+        mockWriter.Setup(w => w.WriteAsync(It.IsAny<OrderFile>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var handler = CreateHandler(db, mockWriter.Object);
+
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        mockWriter.Verify(w => w.WriteAsync(It.IsAny<OrderFile>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SubmittedAt` (nullable `DateTime`) to the `Order` entity with an EF Core migration
- Implements `IOrderFileWriter` / `OrderFileWriter` that writes fixed-width ERP-format files to the configured `Orders:PickupDirectory`
- Implements `OrderFile` which generates the file name (`EXT-XXXXXXXXXX.TXT`) and fixed-width content from the order, customer email, and line items
- Adds `POST /orders/{orderId}/submit` endpoint: validates Draft status, items, both addresses, and shipping estimate; transitions order to Submitted; writes the order file
- Returns 422 for incomplete orders, 409 for non-Draft orders, 403 for wrong customer
- 21 new unit tests covering all handler error paths and `OrderFile` field formatting

## Test plan

- [x] All 172 existing tests still pass (`dotnet test`)
- [x] 21 new tests pass: handler error paths (not found, forbidden, invalid state, missing items/addresses/estimate) and happy path (status, SubmittedAt, file writer called)
- [x] `OrderFileTests` verify file name zero-padding, header fields (order ID, email, date, total weight), address type markers (S/B), and line item zero-padded widget ID and quantity

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)