### PR TITLE
feat: implement order review screen and submission flow (#85)

### DIFF
--- a/src/WidgetDepot.ApiService/Features/Orders/GetDraftOrder/GetDraftOrderHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/GetDraftOrder/GetDraftOrderHandler.cs
@@ -19,7 +19,8 @@ public record GetDraftOrderResponse(
     string Status,
     IReadOnlyList<GetDraftOrderItemResponse> Items,
     GetDraftOrderAddressResponse? ShippingAddress,
-    GetDraftOrderAddressResponse? BillingAddress);
+    GetDraftOrderAddressResponse? BillingAddress,
+    decimal? ShippingEstimate);
 
 public abstract record GetDraftOrderError
 {
@@ -47,7 +48,8 @@ public class GetDraftOrderHandler(AppDbContext db)
             order.Status.ToString(),
             [.. order.Items.Select(i => new GetDraftOrderItemResponse(i.WidgetId, i.Widget.Sku, i.Widget.Name, i.Widget.Weight, i.Quantity))],
             MapAddress(order.ShippingAddress),
-            MapAddress(order.BillingAddress));
+            MapAddress(order.BillingAddress),
+            order.ShippingEstimate);
     }
 
     private static GetDraftOrderAddressResponse? MapAddress(Address? address) =>

--- a/src/WidgetDepot.ApiService/appsettings.json
+++ b/src/WidgetDepot.ApiService/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Orders": {
+    "PickupDirectory": "/tmp/orders"
+  }
 }

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Page.razor
@@ -12,7 +12,7 @@
 <PageTitle>New Order</PageTitle>
 
 <h1>New Order</h1>
-<p class="text-muted lead">Step 1 of 3: Select Widgets</p>
+<p class="text-muted lead">Step 1 of 4: Select Widgets</p>
 
 <div class="row g-4">
     <div class="col-md-7">

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
@@ -11,7 +11,7 @@
 <PageTitle>New Order - Addresses</PageTitle>
 
 <h1>New Order</h1>
-<p class="text-muted lead">Step 2 of 3: Shipping &amp; Billing Addresses</p>
+<p class="text-muted lead">Step 2 of 4: Shipping &amp; Billing Addresses</p>
 
 <EditForm Model="form" OnValidSubmit="HandleContinue">
     <DataAnnotationsValidator />

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step3/Step3Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step3/Step3Page.razor
@@ -12,7 +12,7 @@
 <PageTitle>New Order - Shipping Estimate</PageTitle>
 
 <h1>New Order</h1>
-<p class="text-muted lead">Step 3 of 3: Shipping Estimate</p>
+<p class="text-muted lead">Step 3 of 4: Shipping Estimate</p>
 
 @if (isLoading)
 {

--- a/src/WidgetDepot.Web/Features/Orders/Submit/ConfirmationPage.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Submit/ConfirmationPage.razor
@@ -1,0 +1,23 @@
+@page "/orders/{OrderId:int}/confirmation"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
+
+<PageTitle>Order Submitted</PageTitle>
+
+<h1>Order Submitted</h1>
+
+<div class="alert alert-success mt-3">
+    <p class="mb-1">Your order has been successfully submitted.</p>
+    <p class="mb-0 fw-bold">Order ID: @OrderId</p>
+</div>
+
+<div class="mt-4">
+    <a href="/orders" class="btn btn-outline-secondary me-2">View Draft Orders</a>
+    <a href="/" class="btn btn-primary">Return to Home</a>
+</div>
+
+@code {
+    [Parameter]
+    public int OrderId { get; set; }
+}

--- a/src/WidgetDepot.Web/Features/Orders/Submit/Step4Models.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Submit/Step4Models.cs
@@ -1,0 +1,39 @@
+namespace WidgetDepot.Web.Features.Orders.Submit;
+
+public abstract record GetDraftOrderResult
+{
+    public record Success(GetDraftOrderResponse Order) : GetDraftOrderResult;
+    public record NotFound : GetDraftOrderResult;
+    public record Forbidden : GetDraftOrderResult;
+    public record Failure : GetDraftOrderResult;
+}
+
+public abstract record SubmitOrderResult
+{
+    public record Success(int OrderId) : SubmitOrderResult;
+    public record NotFound : SubmitOrderResult;
+    public record Forbidden : SubmitOrderResult;
+    public record InvalidState : SubmitOrderResult;
+    public record IncompleteOrder(string Reason) : SubmitOrderResult;
+    public record Failure : SubmitOrderResult;
+}
+
+public record GetDraftOrderItemResponse(int WidgetId, string Sku, string Name, decimal Weight, int Quantity);
+
+public record GetDraftOrderAddressResponse(
+    string RecipientName,
+    string StreetLine1,
+    string? StreetLine2,
+    string City,
+    string State,
+    string ZipCode);
+
+public record GetDraftOrderResponse(
+    int Id,
+    string Status,
+    IReadOnlyList<GetDraftOrderItemResponse> Items,
+    GetDraftOrderAddressResponse? ShippingAddress,
+    GetDraftOrderAddressResponse? BillingAddress,
+    decimal? ShippingEstimate);
+
+internal record SubmitOrderApiResponse(int OrderId);

--- a/src/WidgetDepot.Web/Features/Orders/Submit/Step4Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Submit/Step4Page.razor
@@ -1,0 +1,208 @@
+@page "/orders/{OrderId:int}/submit"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
+@using WidgetDepot.Web.Features.Orders.Submit
+@inject Step4Service Step4Service
+@inject NavigationManager NavigationManager
+
+<PageTitle>New Order - Review &amp; Submit</PageTitle>
+
+<h1>New Order</h1>
+<p class="text-muted lead">Step 4 of 4: Review &amp; Submit</p>
+
+@if (isLoading)
+{
+    <p>Loading order details&hellip;</p>
+}
+else if (loadError is not null)
+{
+    <div class="alert alert-danger">@loadError</div>
+    <div class="mt-3">
+        <button type="button" class="btn btn-secondary" @onclick="HandleBack">Back</button>
+    </div>
+}
+else if (order is not null)
+{
+    <div class="mb-4">
+        <h2 class="h5">Order Items</h2>
+        <table class="table table-hover table-sm">
+            <thead>
+                <tr class="table-primary">
+                    <th>Widget</th>
+                    <th>SKU</th>
+                    <th class="text-end">Quantity</th>
+                    <th class="text-end">Weight (lbs)</th>
+                    <th class="text-end">Subtotal (lbs)</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in order.Items)
+                {
+                    <tr>
+                        <td>@item.Name</td>
+                        <td>@item.Sku</td>
+                        <td class="text-end">@item.Quantity</td>
+                        <td class="text-end">@item.Weight.ToString("0.###")</td>
+                        <td class="text-end">@((item.Quantity * item.Weight).ToString("0.###"))</td>
+                    </tr>
+                }
+            </tbody>
+            <tfoot>
+                <tr class="fw-bold">
+                    <td colspan="4" class="text-end">Total weight (lbs)</td>
+                    <td class="text-end">@order.Items.Sum(i => i.Quantity * i.Weight).ToString("0.###")</td>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
+
+    <div class="row mb-4">
+        <div class="col-md-6">
+            <h2 class="h5">Shipping Address</h2>
+            @if (order.ShippingAddress is not null)
+            {
+                <address>
+                    @order.ShippingAddress.RecipientName<br />
+                    @order.ShippingAddress.StreetLine1<br />
+                    @if (!string.IsNullOrEmpty(order.ShippingAddress.StreetLine2))
+                    {
+                        @order.ShippingAddress.StreetLine2<br />
+                    }
+                    @order.ShippingAddress.City, @order.ShippingAddress.State @order.ShippingAddress.ZipCode
+                </address>
+            }
+        </div>
+        <div class="col-md-6">
+            <h2 class="h5">Billing Address</h2>
+            @if (order.BillingAddress is not null)
+            {
+                <address>
+                    @order.BillingAddress.RecipientName<br />
+                    @order.BillingAddress.StreetLine1<br />
+                    @if (!string.IsNullOrEmpty(order.BillingAddress.StreetLine2))
+                    {
+                        @order.BillingAddress.StreetLine2<br />
+                    }
+                    @order.BillingAddress.City, @order.BillingAddress.State @order.BillingAddress.ZipCode
+                </address>
+            }
+        </div>
+    </div>
+
+    <div class="mb-4">
+        <h2 class="h5">Shipping Estimate</h2>
+        @if (order.ShippingEstimate.HasValue)
+        {
+            <p class="fs-4">@order.ShippingEstimate.Value.ToString("C")</p>
+        }
+        else
+        {
+            <p class="text-muted">Not calculated</p>
+        }
+    </div>
+
+    @if (submitError is not null)
+    {
+        <div class="alert alert-danger">@submitError</div>
+    }
+
+    <div class="d-flex gap-2">
+        <button type="button" class="btn btn-secondary" @onclick="HandleBack" disabled="@isSubmitting">Back</button>
+        <button type="button" class="btn btn-primary" @onclick="HandleSubmitAsync" disabled="@isSubmitting">
+            @(isSubmitting ? "Submitting…" : "Submit Order")
+        </button>
+    </div>
+}
+
+@code {
+    [Parameter]
+    public int OrderId { get; set; }
+
+    private bool isLoading = true;
+    private bool isSubmitting;
+    private string? loadError;
+    private string? submitError;
+    private GetDraftOrderResponse? order;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (OrderId <= 0)
+        {
+            NavigationManager.NavigateTo("/orders/new");
+            return;
+        }
+
+        await LoadPageAsync();
+    }
+
+    private async Task LoadPageAsync()
+    {
+        isLoading = true;
+        loadError = null;
+
+        var result = await Step4Service.GetDraftOrderAsync(OrderId);
+
+        switch (result)
+        {
+            case GetDraftOrderResult.NotFound:
+            case GetDraftOrderResult.Forbidden:
+                NavigationManager.NavigateTo("/orders/new");
+                return;
+            case GetDraftOrderResult.Failure:
+                loadError = "Unable to load order details. Please try again.";
+                isLoading = false;
+                return;
+            case GetDraftOrderResult.Success success:
+                order = success.Order;
+                if (order.ShippingAddress is null)
+                {
+                    NavigationManager.NavigateTo($"/orders/{OrderId}/address");
+                    return;
+                }
+                if (!order.ShippingEstimate.HasValue)
+                {
+                    NavigationManager.NavigateTo($"/orders/{OrderId}/shipping");
+                    return;
+                }
+                break;
+        }
+
+        isLoading = false;
+    }
+
+    private void HandleBack()
+    {
+        NavigationManager.NavigateTo($"/orders/{OrderId}/shipping");
+    }
+
+    private async Task HandleSubmitAsync()
+    {
+        isSubmitting = true;
+        submitError = null;
+
+        var result = await Step4Service.SubmitOrderAsync(OrderId);
+
+        switch (result)
+        {
+            case SubmitOrderResult.Success success:
+                NavigationManager.NavigateTo($"/orders/{success.OrderId}/confirmation");
+                return;
+            case SubmitOrderResult.NotFound:
+            case SubmitOrderResult.Forbidden:
+                NavigationManager.NavigateTo("/orders/new");
+                return;
+            case SubmitOrderResult.InvalidState:
+                submitError = "This order has already been submitted.";
+                break;
+            case SubmitOrderResult.IncompleteOrder incomplete:
+                submitError = incomplete.Reason;
+                break;
+            default:
+                submitError = "An unexpected error occurred. Please try again.";
+                break;
+        }
+
+        isSubmitting = false;
+    }
+}

--- a/src/WidgetDepot.Web/Features/Orders/Submit/Step4Service.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Submit/Step4Service.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace WidgetDepot.Web.Features.Orders.Submit;
+
+public class Step4Service
+{
+    private readonly HttpClient _httpClient;
+
+    public Step4Service(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<GetDraftOrderResult> GetDraftOrderAsync(int orderId, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync($"/orders/{orderId}/draft", cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var order = await response.Content.ReadFromJsonAsync<GetDraftOrderResponse>(cancellationToken);
+            return order is null
+                ? new GetDraftOrderResult.Failure()
+                : new GetDraftOrderResult.Success(order);
+        }
+
+        return response.StatusCode switch
+        {
+            HttpStatusCode.NotFound => new GetDraftOrderResult.NotFound(),
+            HttpStatusCode.Forbidden => new GetDraftOrderResult.Forbidden(),
+            _ => new GetDraftOrderResult.Failure()
+        };
+    }
+
+    public async Task<SubmitOrderResult> SubmitOrderAsync(int orderId, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.PostAsync($"/orders/{orderId}/submit", null, cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var result = await response.Content.ReadFromJsonAsync<SubmitOrderApiResponse>(cancellationToken);
+            return result is null
+                ? new SubmitOrderResult.Failure()
+                : new SubmitOrderResult.Success(result.OrderId);
+        }
+
+        return response.StatusCode switch
+        {
+            HttpStatusCode.NotFound => new SubmitOrderResult.NotFound(),
+            HttpStatusCode.Forbidden => new SubmitOrderResult.Forbidden(),
+            HttpStatusCode.Conflict => new SubmitOrderResult.InvalidState(),
+            HttpStatusCode.UnprocessableEntity => new SubmitOrderResult.IncompleteOrder("Order is missing required information."),
+            _ => new SubmitOrderResult.Failure()
+        };
+    }
+}

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -16,6 +16,7 @@ using WidgetDepot.Web.Features.Orders.Create.Step1;
 using WidgetDepot.Web.Features.Orders.Create.Step2;
 using WidgetDepot.Web.Features.Orders.Create.Step3;
 using WidgetDepot.Web.Features.Orders.List;
+using WidgetDepot.Web.Features.Orders.Submit;
 using WidgetDepot.Web.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -73,6 +74,10 @@ builder.Services.AddHttpClient<Step3Service>(client =>
     .AddHttpMessageHandler<CookieForwardingHandler>();
 
 builder.Services.AddHttpClient<ListService>(client =>
+    client.BaseAddress = new Uri("https+http://apiservice"))
+    .AddHttpMessageHandler<CookieForwardingHandler>();
+
+builder.Services.AddHttpClient<Step4Service>(client =>
     client.BaseAddress = new Uri("https+http://apiservice"))
     .AddHttpMessageHandler<CookieForwardingHandler>();
 

--- a/tests/WidgetDepot.Tests/Features/Orders/Submit/Step4ServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/Submit/Step4ServiceTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Text;
+
+using Shouldly;
+
+using WidgetDepot.Web.Features.Orders.Submit;
+
+namespace WidgetDepot.Tests.Features.Orders.Submit;
+
+public class Step4ServiceTests
+{
+    private static Step4Service CreateService(HttpStatusCode statusCode, string? responseContent = null)
+    {
+        var handler = new FakeHttpMessageHandler(statusCode, responseContent);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        return new Step4Service(httpClient);
+    }
+
+    [Fact]
+    public async Task GetDraftOrderAsync_OkResponse_ReturnsSuccessWithOrder()
+    {
+        var json = """{"id":7,"status":"Draft","items":[{"widgetId":1,"sku":"W-001","name":"Sprocket","weight":2.0,"quantity":3}],"shippingAddress":{"recipientName":"Alice","streetLine1":"123 Main","streetLine2":null,"city":"Springfield","state":"IL","zipCode":"62701"},"billingAddress":null,"shippingEstimate":14.99}""";
+        var service = CreateService(HttpStatusCode.OK, json);
+
+        var result = await service.GetDraftOrderAsync(7, TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetDraftOrderResult.Success>();
+        success.Order.Id.ShouldBe(7);
+        success.Order.Items.Count.ShouldBe(1);
+        success.Order.ShippingEstimate.ShouldBe(14.99m);
+    }
+
+    [Fact]
+    public async Task GetDraftOrderAsync_NotFoundResponse_ReturnsNotFound()
+    {
+        var service = CreateService(HttpStatusCode.NotFound);
+
+        var result = await service.GetDraftOrderAsync(999, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftOrderResult.NotFound>();
+    }
+
+    [Fact]
+    public async Task GetDraftOrderAsync_ForbiddenResponse_ReturnsForbidden()
+    {
+        var service = CreateService(HttpStatusCode.Forbidden);
+
+        var result = await service.GetDraftOrderAsync(7, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftOrderResult.Forbidden>();
+    }
+
+    [Fact]
+    public async Task GetDraftOrderAsync_ServerErrorResponse_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError);
+
+        var result = await service.GetDraftOrderAsync(7, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftOrderResult.Failure>();
+    }
+
+    [Fact]
+    public async Task SubmitOrderAsync_OkResponse_ReturnsSuccessWithOrderId()
+    {
+        var json = """{"orderId":7}""";
+        var service = CreateService(HttpStatusCode.OK, json);
+
+        var result = await service.SubmitOrderAsync(7, TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<SubmitOrderResult.Success>();
+        success.OrderId.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task SubmitOrderAsync_NotFoundResponse_ReturnsNotFound()
+    {
+        var service = CreateService(HttpStatusCode.NotFound);
+
+        var result = await service.SubmitOrderAsync(999, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitOrderResult.NotFound>();
+    }
+
+    [Fact]
+    public async Task SubmitOrderAsync_ForbiddenResponse_ReturnsForbidden()
+    {
+        var service = CreateService(HttpStatusCode.Forbidden);
+
+        var result = await service.SubmitOrderAsync(7, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitOrderResult.Forbidden>();
+    }
+
+    [Fact]
+    public async Task SubmitOrderAsync_ConflictResponse_ReturnsInvalidState()
+    {
+        var service = CreateService(HttpStatusCode.Conflict);
+
+        var result = await service.SubmitOrderAsync(7, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitOrderResult.InvalidState>();
+    }
+
+    [Fact]
+    public async Task SubmitOrderAsync_UnprocessableEntityResponse_ReturnsIncompleteOrder()
+    {
+        var service = CreateService(HttpStatusCode.UnprocessableEntity);
+
+        var result = await service.SubmitOrderAsync(7, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitOrderResult.IncompleteOrder>();
+    }
+
+    [Fact]
+    public async Task SubmitOrderAsync_ServerErrorResponse_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError);
+
+        var result = await service.SubmitOrderAsync(7, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitOrderResult.Failure>();
+    }
+
+    private class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly string _responseContent;
+
+        public FakeHttpMessageHandler(HttpStatusCode statusCode, string? responseContent = null)
+        {
+            _statusCode = statusCode;
+            _responseContent = responseContent ?? "{}";
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_responseContent, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds wizard step 4 (review & submit) at `/orders/{id}/submit` displaying a full order summary: items with SKU/quantity/weight, shipping address, billing address, and estimated shipping cost
- Submit button calls `POST /orders/{id}/submit` (existing API endpoint); on success redirects to a confirmation page at `/orders/{id}/confirmation` showing the order ID
- Extends `GetDraftOrderResponse` in the API to include `ShippingEstimate`, eliminating a redundant HTTP round-trip on the review screen
- Updates step count labels in steps 1–3 from "of 3" to "of 4"
- Submitted orders continue to be excluded from the draft orders list (the `/orders/drafts` API already filters by `Draft` status)

## Test plan

- [ ] Build succeeds with no warnings
- [ ] All 182 existing tests pass; 10 new `Step4ServiceTests` added
- [ ] Navigate through wizard steps 1–4 and verify step labels show "Step X of 4"
- [ ] Review screen shows correct widgets, addresses, and shipping estimate
- [ ] "Back" returns to step 3 without changing the order
- [ ] "Submit Order" submits and redirects to confirmation page with the order ID
- [ ] Submitted order no longer appears in the draft orders list at `/orders`

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)