### PR TITLE
Fix resume draft order wizard and add nav links

### DIFF
--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
@@ -5,6 +5,7 @@ using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.GetDrafts;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
 using WidgetDepot.ApiService.Features.Orders.Submit;
+using WidgetDepot.ApiService.Features.Orders.UpdateDraftItems;
 
 namespace WidgetDepot.ApiService.Features.Orders;
 
@@ -19,6 +20,7 @@ public static class OrderEndpointExtensions
         app.MapCalculateShipping();
         app.MapDeleteDraft();
         app.MapSubmitOrder();
+        app.MapUpdateDraftItems();
 
         return app;
     }

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
@@ -11,4 +11,5 @@ public static class OrderEndpoints
     public const string GetDrafts = $"{Base}/drafts";
     public const string DeleteDraft = $"{Base}/{{orderId}}/draft";
     public const string SubmitOrder = $"{Base}/{{orderId}}/submit";
+    public const string UpdateDraftItems = $"{Base}/{{orderId}}/items";
 }

--- a/src/WidgetDepot.ApiService/Features/Orders/UpdateDraftItems/UpdateDraftItemsEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/UpdateDraftItems/UpdateDraftItemsEndpoint.cs
@@ -1,0 +1,36 @@
+using System.Security.Claims;
+
+namespace WidgetDepot.ApiService.Features.Orders.UpdateDraftItems;
+
+public static class UpdateDraftItemsEndpoint
+{
+    public static IEndpointRouteBuilder MapUpdateDraftItems(this IEndpointRouteBuilder app)
+    {
+        app.MapPut(OrderEndpoints.UpdateDraftItems, async (
+            int orderId,
+            UpdateDraftItemsRequest request,
+            ClaimsPrincipal user,
+            UpdateDraftItemsHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            if (!user.TryGetCustomerId(out var customerId))
+                return Results.Unauthorized();
+
+            var result = await handler.HandleAsync(orderId, customerId, request, cancellationToken);
+
+            return result switch
+            {
+                UpdateDraftItemsError.OrderNotFound => Results.NotFound(),
+                UpdateDraftItemsError.Forbidden => Results.Forbid(),
+                UpdateDraftItemsError.NotDraft => Results.Conflict(),
+                UpdateDraftItemsError.WidgetNotFound error => Results.BadRequest(new { error.WidgetId }),
+                null => Results.NoContent(),
+                _ => Results.Problem(statusCode: 500)
+            };
+        })
+        .WithName("UpdateDraftItems")
+        .RequireAuthorization();
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/UpdateDraftItems/UpdateDraftItemsHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/UpdateDraftItems/UpdateDraftItemsHandler.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Orders.UpdateDraftItems;
+
+public record UpdateDraftItemRequest(int WidgetId, int Quantity);
+
+public record UpdateDraftItemsRequest(IReadOnlyList<UpdateDraftItemRequest> Items);
+
+public abstract record UpdateDraftItemsError
+{
+    public record OrderNotFound : UpdateDraftItemsError;
+    public record Forbidden : UpdateDraftItemsError;
+    public record NotDraft : UpdateDraftItemsError;
+    public record WidgetNotFound(int WidgetId) : UpdateDraftItemsError;
+}
+
+public class UpdateDraftItemsHandler(AppDbContext db)
+{
+    public async Task<object?> HandleAsync(int orderId, int customerId, UpdateDraftItemsRequest request, CancellationToken cancellationToken)
+    {
+        var order = await db.Orders
+            .Include(o => o.Items)
+            .FirstOrDefaultAsync(o => o.Id == orderId, cancellationToken);
+
+        if (order is null)
+            return new UpdateDraftItemsError.OrderNotFound();
+
+        if (order.CustomerId != customerId)
+            return new UpdateDraftItemsError.Forbidden();
+
+        if (order.Status != OrderStatus.Draft)
+            return new UpdateDraftItemsError.NotDraft();
+
+        order.Items.Clear();
+
+        foreach (var item in request.Items)
+        {
+            var widget = await db.Widgets
+                .FirstOrDefaultAsync(w => w.Id == item.WidgetId, cancellationToken);
+
+            if (widget is null)
+                return new UpdateDraftItemsError.WidgetNotFound(item.WidgetId);
+
+            order.Items.Add(new OrderItem
+            {
+                WidgetId = item.WidgetId,
+                Quantity = item.Quantity
+            });
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        return null;
+    }
+}

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -14,6 +14,7 @@ using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.GetDrafts;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
 using WidgetDepot.ApiService.Features.Orders.Submit;
+using WidgetDepot.ApiService.Features.Orders.UpdateDraftItems;
 using WidgetDepot.ApiService.Features.Widgets.Import;
 using WidgetDepot.ApiService.Features.Widgets.Search;
 
@@ -65,6 +66,7 @@ builder.Services.AddScoped<LoginHandler>();
 builder.Services.AddScoped<ProfileHandler>();
 builder.Services.AddScoped<PasswordChangeHandler>();
 builder.Services.AddScoped<SubmitOrderHandler>();
+builder.Services.AddScoped<UpdateDraftItemsHandler>();
 builder.Services.AddScoped<IOrderFileWriter, OrderFileWriter>();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi

--- a/src/WidgetDepot.Web/Components/Layout/NavMenu.razor
+++ b/src/WidgetDepot.Web/Components/Layout/NavMenu.razor
@@ -27,6 +27,16 @@
         <AuthorizeView>
             <Authorized>
                 <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="orders">
+                        <span class="bi bi-file-text-fill" aria-hidden="true"></span> My Draft Orders
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="orders/new">
+                        <span class="bi bi-plus-circle-fill" aria-hidden="true"></span> New Order
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
                     <NavLink class="nav-link" href="accounts/profile">
                         <span class="bi bi-person-fill" aria-hidden="true"></span> Profile
                     </NavLink>

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Models.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Models.cs
@@ -35,6 +35,16 @@ public record GetDraftStep1ItemResponse(int WidgetId, string Sku, string Name, d
 
 public record GetDraftStep1Response(int Id, string Status, IReadOnlyList<GetDraftStep1ItemResponse> Items);
 
+public record UpdateDraftRequest(IReadOnlyList<UpdateDraftItemRequest> Items);
+
+public record UpdateDraftItemRequest(int WidgetId, int Quantity);
+
+public abstract record UpdateDraftResult
+{
+    public record Success : UpdateDraftResult;
+    public record Failure : UpdateDraftResult;
+}
+
 public abstract record GetDraftStep1Result
 {
     public record Success(GetDraftStep1Response Order) : GetDraftStep1Result;

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Page.razor
@@ -223,18 +223,36 @@
 
         try
         {
-            var result = await Step1Service.CreateDraftAsync(selectedItems);
-
-            switch (result)
+            if (OrderId > 0)
             {
-                case CreateDraftResult.Success success:
-                    WizardState.OrderId = success.OrderId;
+                var result = await Step1Service.UpdateDraftAsync(OrderId, selectedItems);
+
+                if (result is UpdateDraftResult.Success)
+                {
+                    WizardState.OrderId = OrderId;
                     WizardState.SelectedItems = new List<OrderItemModel>(selectedItems);
-                    NavigationManager.NavigateTo($"/orders/{success.OrderId}/address");
-                    break;
-                default:
+                    NavigationManager.NavigateTo($"/orders/{OrderId}/address");
+                }
+                else
+                {
                     errorMessage = "An unexpected error occurred. Please try again.";
-                    break;
+                }
+            }
+            else
+            {
+                var result = await Step1Service.CreateDraftAsync(selectedItems);
+
+                switch (result)
+                {
+                    case CreateDraftResult.Success success:
+                        WizardState.OrderId = success.OrderId;
+                        WizardState.SelectedItems = new List<OrderItemModel>(selectedItems);
+                        NavigationManager.NavigateTo($"/orders/{success.OrderId}/address");
+                        break;
+                    default:
+                        errorMessage = "An unexpected error occurred. Please try again.";
+                        break;
+                }
             }
         }
         catch (Exception)

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Service.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Service.cs
@@ -48,4 +48,16 @@ public class Step1Service(HttpClient httpClient)
 
         return new CreateDraftResult.Failure();
     }
+
+    public async Task<UpdateDraftResult> UpdateDraftAsync(int orderId, IReadOnlyList<OrderItemModel> items, CancellationToken cancellationToken = default)
+    {
+        var request = new UpdateDraftRequest(
+            items.Select(i => new UpdateDraftItemRequest(i.WidgetId, i.Quantity)).ToList());
+
+        var response = await httpClient.PutAsJsonAsync($"/orders/{orderId}/items", request, cancellationToken);
+
+        return response.StatusCode == System.Net.HttpStatusCode.NoContent
+            ? new UpdateDraftResult.Success()
+            : new UpdateDraftResult.Failure();
+    }
 }

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
@@ -218,7 +218,7 @@
     private void HandleBack()
     {
         SaveToState();
-        NavigationManager.NavigateTo("/orders/new");
+        NavigationManager.NavigateTo($"/orders/{OrderId}/step1");
     }
 
     private async Task HandleContinue()

--- a/tests/WidgetDepot.Tests/Features/Orders/UpdateDraftItems/UpdateDraftItemsHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/UpdateDraftItems/UpdateDraftItemsHandlerTests.cs
@@ -1,0 +1,107 @@
+using Microsoft.EntityFrameworkCore;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.UpdateDraftItems;
+
+namespace WidgetDepot.Tests.Features.Orders.UpdateDraftItems;
+
+public class UpdateDraftItemsHandlerTests
+{
+    private AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidRequest_ReplacesExistingItems()
+    {
+        using var db = CreateDb();
+        var widget1 = new Widget { Id = 1, Name = "Sprocket", Sku = "SPR-001", Weight = 1.0m };
+        var widget2 = new Widget { Id = 2, Name = "Cog", Sku = "COG-001", Weight = 2.0m };
+        db.Widgets.AddRange(widget1, widget2);
+        var order = new Order
+        {
+            Id = 1,
+            CustomerId = 42,
+            Status = OrderStatus.Draft,
+            CreatedAt = DateTime.UtcNow,
+            Items = [new OrderItem { WidgetId = 1, Quantity = 3 }]
+        };
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var handler = new UpdateDraftItemsHandler(db);
+        var request = new UpdateDraftItemsRequest([new UpdateDraftItemRequest(2, 5)]);
+
+        var result = await handler.HandleAsync(1, 42, request, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+        var updated = await db.Orders.Include(o => o.Items).FirstAsync(TestContext.Current.CancellationToken);
+        updated.Items.Count.ShouldBe(1);
+        updated.Items.First().WidgetId.ShouldBe(2);
+        updated.Items.First().Quantity.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderNotFound_ReturnsOrderNotFound()
+    {
+        using var db = CreateDb();
+        var handler = new UpdateDraftItemsHandler(db);
+        var request = new UpdateDraftItemsRequest([new UpdateDraftItemRequest(1, 1)]);
+
+        var result = await handler.HandleAsync(999, 42, request, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<UpdateDraftItemsError.OrderNotFound>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WrongCustomer_ReturnsForbidden()
+    {
+        using var db = CreateDb();
+        db.Orders.Add(new Order { Id = 1, CustomerId = 42, Status = OrderStatus.Draft, CreatedAt = DateTime.UtcNow });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var handler = new UpdateDraftItemsHandler(db);
+        var request = new UpdateDraftItemsRequest([new UpdateDraftItemRequest(1, 1)]);
+
+        var result = await handler.HandleAsync(1, 99, request, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<UpdateDraftItemsError.Forbidden>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonDraftOrder_ReturnsNotDraft()
+    {
+        using var db = CreateDb();
+        db.Orders.Add(new Order { Id = 1, CustomerId = 42, Status = OrderStatus.Submitted, CreatedAt = DateTime.UtcNow });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var handler = new UpdateDraftItemsHandler(db);
+        var request = new UpdateDraftItemsRequest([new UpdateDraftItemRequest(1, 1)]);
+
+        var result = await handler.HandleAsync(1, 42, request, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<UpdateDraftItemsError.NotDraft>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_UnknownWidgetId_ReturnsWidgetNotFound()
+    {
+        using var db = CreateDb();
+        db.Orders.Add(new Order { Id = 1, CustomerId = 42, Status = OrderStatus.Draft, CreatedAt = DateTime.UtcNow });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var handler = new UpdateDraftItemsHandler(db);
+        var request = new UpdateDraftItemsRequest([new UpdateDraftItemRequest(999, 1)]);
+
+        var result = await handler.HandleAsync(1, 42, request, TestContext.Current.CancellationToken);
+
+        var error = result.ShouldBeOfType<UpdateDraftItemsError.WidgetNotFound>();
+        error.WidgetId.ShouldBe(999);
+    }
+}


### PR DESCRIPTION
## Summary

- **Resume draft bug**: When resuming a draft order, clicking Continue on Step 1 was always calling `POST /orders/draft` and creating a new order. Added a `PUT /orders/{orderId}/items` endpoint so the existing draft is updated instead. Step 1's `HandleContinue` now branches on whether `OrderId > 0`.
- **Back button bug**: Step 2's Back button was navigating to `/orders/new` instead of `/orders/{orderId}/step1`, causing the same new-order problem when going backwards. Fixed to use the correct route.
- **Nav links**: Added "My Draft Orders" and "New Order" links to the sidebar nav, visible only to authenticated users.

## Test plan

- [x] Build passes (`dotnet build`)
- [x] All 188 tests pass (`dotnet test`), including 5 new `UpdateDraftItemsHandlerTests`
- [x] Start a new order, add widgets, click Continue → lands on Step 2
- [x] On Step 2, click Back → lands on `/orders/{id}/step1` with widgets pre-populated (not `/orders/new`)
- [x] Modify widgets, click Continue → updates the existing draft (same order ID in URL), proceeds to Step 3
- [x] Resume a draft from the My Draft Orders list → navigate forward and backward through all steps without creating duplicate drafts
- [x] Verify "My Draft Orders" and "New Order" nav links appear when logged in and are absent when logged out

🤖 Generated with [Claude Code](https://claude.com/claude-code)