### PR TITLE
feat: implement 30-day draft order auto-expiry

### DIFF
--- a/src/WidgetDepot.ApiService/Features/Orders/ExpireDraftOrders/ExpireDraftOrdersHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/ExpireDraftOrders/ExpireDraftOrdersHandler.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Orders.ExpireDraftOrders;
+
+public class ExpireDraftOrdersHandler
+{
+    private readonly AppDbContext _db;
+
+    public ExpireDraftOrdersHandler(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<int> HandleAsync(CancellationToken cancellationToken)
+    {
+        var cutoff = DateTime.UtcNow.AddDays(-30);
+
+        var expired = await _db.Orders
+            .Where(o => o.Status == OrderStatus.Draft && o.CreatedAt < cutoff)
+            .ToListAsync(cancellationToken);
+
+        _db.Orders.RemoveRange(expired);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return expired.Count;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/ExpireDraftOrders/ExpireDraftOrdersJob.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/ExpireDraftOrders/ExpireDraftOrdersJob.cs
@@ -1,0 +1,57 @@
+namespace WidgetDepot.ApiService.Features.Orders.ExpireDraftOrders;
+
+public class ExpireDraftOrdersJob : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<ExpireDraftOrdersJob> _logger;
+    private readonly int _scheduleHourUtc;
+
+    public ExpireDraftOrdersJob(
+        IServiceScopeFactory scopeFactory,
+        ILogger<ExpireDraftOrdersJob> logger,
+        IConfiguration configuration)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _scheduleHourUtc = configuration.GetValue("DraftOrderExpiry:ScheduleHourUtc", 0);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var delay = TimeUntilNextScheduledRun();
+
+            try
+            {
+                await Task.Delay(delay, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+
+            await RunJobAsync(stoppingToken);
+        }
+    }
+
+    private async Task RunJobAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var handler = scope.ServiceProvider.GetRequiredService<ExpireDraftOrdersHandler>();
+
+        var deleted = await handler.HandleAsync(cancellationToken);
+        _logger.LogInformation("ExpireDraftOrdersJob: deleted {Count} expired draft order(s).", deleted);
+    }
+
+    private TimeSpan TimeUntilNextScheduledRun()
+    {
+        var now = DateTime.UtcNow;
+        var nextRun = now.Date.AddHours(_scheduleHourUtc);
+
+        if (nextRun <= now)
+            nextRun = nextRun.AddDays(1);
+
+        return nextRun - now;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/ExpireDraftOrders/ExpireDraftOrdersJob.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/ExpireDraftOrders/ExpireDraftOrdersJob.cs
@@ -5,6 +5,7 @@ public class ExpireDraftOrdersJob : BackgroundService
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<ExpireDraftOrdersJob> _logger;
     private readonly int _scheduleHourUtc;
+    private bool _first = true;
 
     public ExpireDraftOrdersJob(
         IServiceScopeFactory scopeFactory,
@@ -24,6 +25,7 @@ public class ExpireDraftOrdersJob : BackgroundService
 
             try
             {
+                _logger.LogInformation("ExpireDraftOrdersJob: Delaying for {Delay}", delay);
                 await Task.Delay(delay, stoppingToken);
             }
             catch (OperationCanceledException)
@@ -46,6 +48,13 @@ public class ExpireDraftOrdersJob : BackgroundService
 
     private TimeSpan TimeUntilNextScheduledRun()
     {
+        if (_first)
+        {
+            // Run the job on startup
+            _first = false;
+            return TimeSpan.Zero;            
+        }
+
         var now = DateTime.UtcNow;
         var nextRun = now.Date.AddHours(_scheduleHourUtc);
 

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
-
 using WidgetDepot.ApiService.Data;
 using WidgetDepot.ApiService.Features.Accounts.Login;
 using WidgetDepot.ApiService.Features.Accounts.PasswordChange;
@@ -10,6 +9,7 @@ using WidgetDepot.ApiService.Features.Accounts.Register;
 using WidgetDepot.ApiService.Features.Orders.CalculateShipping;
 using WidgetDepot.ApiService.Features.Orders.CreateDraft;
 using WidgetDepot.ApiService.Features.Orders.DeleteDraft;
+using WidgetDepot.ApiService.Features.Orders.ExpireDraftOrders;
 using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.GetDrafts;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
@@ -68,6 +68,8 @@ builder.Services.AddScoped<PasswordChangeHandler>();
 builder.Services.AddScoped<SubmitOrderHandler>();
 builder.Services.AddScoped<UpdateDraftItemsHandler>();
 builder.Services.AddScoped<IOrderFileWriter, OrderFileWriter>();
+builder.Services.AddScoped<ExpireDraftOrdersHandler>();
+builder.Services.AddHostedService<ExpireDraftOrdersJob>();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();

--- a/tests/WidgetDepot.Tests/Features/Orders/ExpireDraftOrders/ExpireDraftOrdersHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/ExpireDraftOrders/ExpireDraftOrdersHandlerTests.cs
@@ -1,0 +1,145 @@
+using Microsoft.EntityFrameworkCore;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.ExpireDraftOrders;
+
+namespace WidgetDepot.Tests.Features.Orders.ExpireDraftOrders;
+
+public class ExpireDraftOrdersHandlerTests
+{
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static async Task SeedOrderAsync(AppDbContext db, OrderStatus status, DateTime createdAt)
+    {
+        var order = new Order
+        {
+            CustomerId = 1,
+            Status = status,
+            CreatedAt = createdAt
+        };
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoDraftOrders_ReturnsZero()
+    {
+        using var db = CreateDb();
+        var handler = new ExpireDraftOrdersHandler(db);
+
+        var result = await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DraftOrderOlderThan30Days_ReturnsDeletedCount()
+    {
+        using var db = CreateDb();
+        await SeedOrderAsync(db, OrderStatus.Draft, DateTime.UtcNow.AddDays(-31));
+        var handler = new ExpireDraftOrdersHandler(db);
+
+        var result = await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DraftOrderOlderThan30Days_DeletesOrder()
+    {
+        using var db = CreateDb();
+        await SeedOrderAsync(db, OrderStatus.Draft, DateTime.UtcNow.AddDays(-31));
+        var handler = new ExpireDraftOrdersHandler(db);
+
+        await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        var remaining = await db.Orders.CountAsync(TestContext.Current.CancellationToken);
+        remaining.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DraftOrderExactly30DaysOld_DoesNotDelete()
+    {
+        using var db = CreateDb();
+        await SeedOrderAsync(db, OrderStatus.Draft, DateTime.UtcNow.AddDays(-30).AddMinutes(1));
+        var handler = new ExpireDraftOrdersHandler(db);
+
+        var result = await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task HandleAsync_SubmittedOrderOlderThan30Days_DoesNotDelete()
+    {
+        using var db = CreateDb();
+        await SeedOrderAsync(db, OrderStatus.Submitted, DateTime.UtcNow.AddDays(-60));
+        var handler = new ExpireDraftOrdersHandler(db);
+
+        var result = await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task HandleAsync_SubmittedOrderOlderThan30Days_LeavesOrderIntact()
+    {
+        using var db = CreateDb();
+        await SeedOrderAsync(db, OrderStatus.Submitted, DateTime.UtcNow.AddDays(-60));
+        var handler = new ExpireDraftOrdersHandler(db);
+
+        await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        var remaining = await db.Orders.CountAsync(TestContext.Current.CancellationToken);
+        remaining.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task HandleAsync_RecentDraftOrder_DoesNotDelete()
+    {
+        using var db = CreateDb();
+        await SeedOrderAsync(db, OrderStatus.Draft, DateTime.UtcNow.AddDays(-5));
+        var handler = new ExpireDraftOrdersHandler(db);
+
+        var result = await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task HandleAsync_MixedOrders_DeletesOnlyExpiredDrafts()
+    {
+        using var db = CreateDb();
+        await SeedOrderAsync(db, OrderStatus.Draft, DateTime.UtcNow.AddDays(-31));   // expired draft
+        await SeedOrderAsync(db, OrderStatus.Draft, DateTime.UtcNow.AddDays(-5));    // recent draft
+        await SeedOrderAsync(db, OrderStatus.Submitted, DateTime.UtcNow.AddDays(-60)); // old submitted
+        var handler = new ExpireDraftOrdersHandler(db);
+
+        var result = await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(1);
+        var remaining = await db.Orders.CountAsync(TestContext.Current.CancellationToken);
+        remaining.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task HandleAsync_CalledTwice_IsIdempotent()
+    {
+        using var db = CreateDb();
+        await SeedOrderAsync(db, OrderStatus.Draft, DateTime.UtcNow.AddDays(-31));
+        var handler = new ExpireDraftOrdersHandler(db);
+
+        await handler.HandleAsync(TestContext.Current.CancellationToken);
+        var secondResult = await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        secondResult.ShouldBe(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ExpireDraftOrdersHandler` that deletes all `Draft` orders with `CreatedAt` older than 30 days and returns the count of deleted orders
- Adds `ExpireDraftOrdersJob` (`BackgroundService`) that runs the handler once per day at a configurable UTC hour (default midnight UTC via `DraftOrderExpiry:ScheduleHourUtc` in config)
- Registers both in `Program.cs`; 9 unit tests cover expiry logic, status filtering, boundary conditions, and idempotency

## Test plan

- [x] All 9 new `ExpireDraftOrdersHandlerTests` pass
- [x] Full test suite (196 passing, 1 pre-existing skip) unaffected
- [x] Handler only deletes `Draft` orders, never `Submitted` orders
- [x] Running the handler twice on the same data returns 0 on the second call (idempotent)
- [x] Schedule hour configurable: set `DraftOrderExpiry:ScheduleHourUtc` in `appsettings.json`

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)