### PR TITLE
feat: implement GetByOrderNumber API endpoint

### DIFF
--- a/src/WidgetDepot.ApiService/Features/Orders/GetByOrderNumber/GetByOrderNumberEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/GetByOrderNumber/GetByOrderNumberEndpoint.cs
@@ -1,0 +1,32 @@
+using System.Security.Claims;
+
+namespace WidgetDepot.ApiService.Features.Orders.GetByOrderNumber;
+
+public static class GetByOrderNumberEndpoint
+{
+    public static IEndpointRouteBuilder MapGetByOrderNumber(this IEndpointRouteBuilder app)
+    {
+        app.MapGet(OrderEndpoints.GetByOrderNumber, async (
+            int orderNumber,
+            ClaimsPrincipal user,
+            GetByOrderNumberHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            if (!user.TryGetCustomerId(out var customerId))
+                return Results.Unauthorized();
+
+            var result = await handler.HandleAsync(orderNumber, customerId, cancellationToken);
+
+            return result switch
+            {
+                GetByOrderNumberNotFound => Results.NotFound(),
+                GetByOrderNumberResponse response => Results.Ok(response),
+                _ => Results.Problem(statusCode: 500)
+            };
+        })
+        .WithName("GetByOrderNumber")
+        .RequireAuthorization();
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/GetByOrderNumber/GetByOrderNumberHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/GetByOrderNumber/GetByOrderNumberHandler.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Orders.GetByOrderNumber;
+
+public record GetByOrderNumberItemResponse(int WidgetId, string Sku, string Name, decimal Weight, decimal UnitCost, int Quantity);
+
+public record GetByOrderNumberAddressResponse(
+    string RecipientName,
+    string StreetLine1,
+    string? StreetLine2,
+    string City,
+    string State,
+    string ZipCode);
+
+public record GetByOrderNumberResponse(
+    int Id,
+    string Status,
+    DateTime CreatedAt,
+    DateTime? SubmittedAt,
+    IReadOnlyList<GetByOrderNumberItemResponse> Items,
+    GetByOrderNumberAddressResponse? ShippingAddress,
+    GetByOrderNumberAddressResponse? BillingAddress,
+    decimal? ShippingEstimate);
+
+public record GetByOrderNumberNotFound;
+
+public class GetByOrderNumberHandler(AppDbContext db)
+{
+    public async Task<object> HandleAsync(int orderNumber, int customerId, CancellationToken cancellationToken)
+    {
+        var order = await db.Orders
+            .Include(o => o.Items)
+            .ThenInclude(i => i.Widget)
+            .FirstOrDefaultAsync(o => o.Id == orderNumber && o.CustomerId == customerId, cancellationToken);
+
+        if (order is null)
+            return new GetByOrderNumberNotFound();
+
+        return new GetByOrderNumberResponse(
+            order.Id,
+            order.Status.ToString(),
+            order.CreatedAt,
+            order.SubmittedAt,
+            [.. order.Items.Select(i => new GetByOrderNumberItemResponse(i.WidgetId, i.Widget.Sku, i.Widget.Name, i.Widget.Weight, i.Widget.Price, i.Quantity))],
+            MapAddress(order.ShippingAddress),
+            MapAddress(order.BillingAddress),
+            order.ShippingEstimate);
+    }
+
+    private static GetByOrderNumberAddressResponse? MapAddress(Address? address) =>
+        address is null ? null : new GetByOrderNumberAddressResponse(
+            address.RecipientName,
+            address.StreetLine1,
+            address.StreetLine2,
+            address.City,
+            address.State,
+            address.ZipCode);
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
@@ -1,6 +1,7 @@
 using WidgetDepot.ApiService.Features.Orders.CalculateShipping;
 using WidgetDepot.ApiService.Features.Orders.CreateDraft;
 using WidgetDepot.ApiService.Features.Orders.DeleteDraft;
+using WidgetDepot.ApiService.Features.Orders.GetByOrderNumber;
 using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.GetDrafts;
 using WidgetDepot.ApiService.Features.Orders.GetRecentSubmitted;
@@ -23,6 +24,7 @@ public static class OrderEndpointExtensions
         app.MapSubmitOrder();
         app.MapUpdateDraftItems();
         app.MapGetRecentSubmitted();
+        app.MapGetByOrderNumber();
 
         return app;
     }

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
@@ -13,4 +13,5 @@ public static class OrderEndpoints
     public const string SubmitOrder = $"{Base}/{{orderId}}/submit";
     public const string UpdateDraftItems = $"{Base}/{{orderId}}/items";
     public const string GetRecentSubmitted = $"{Base}/recent";
+    public const string GetByOrderNumber = $"{Base}/{{orderNumber}}";
 }

--- a/tests/WidgetDepot.Tests/Features/Orders/GetByOrderNumber/GetByOrderNumberHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/GetByOrderNumber/GetByOrderNumberHandlerTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.EntityFrameworkCore;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.GetByOrderNumber;
+
+namespace WidgetDepot.Tests.Features.Orders.GetByOrderNumber;
+
+public class GetByOrderNumberHandlerTests
+{
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static async Task<Order> SeedOrderAsync(AppDbContext db, int customerId = 1, OrderStatus status = OrderStatus.Draft)
+    {
+        var order = new Order
+        {
+            CustomerId = customerId,
+            Status = status,
+            CreatedAt = DateTime.UtcNow,
+            SubmittedAt = status == OrderStatus.Submitted ? DateTime.UtcNow : null
+        };
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return order;
+    }
+
+    private static async Task<Widget> SeedWidgetAsync(AppDbContext db)
+    {
+        var widget = new Widget
+        {
+            Sku = "SPR-001",
+            Name = "Sprocket",
+            Description = "A sprocket",
+            Manufacturer = "Acme",
+            Weight = 1.5m,
+            Price = 9.99m,
+            DateAvailable = new DateOnly(2026, 1, 1)
+        };
+        db.Widgets.Add(widget);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return widget;
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderNotFound_ReturnsNotFound()
+    {
+        using var db = CreateDb();
+        var handler = new GetByOrderNumberHandler(db);
+
+        var result = await handler.HandleAsync(999, 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetByOrderNumberNotFound>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderBelongsToDifferentCustomer_ReturnsNotFound()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1);
+        var handler = new GetByOrderNumberHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, 2, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetByOrderNumberNotFound>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_DraftOrderBelongsToCustomer_ReturnsResponse()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, status: OrderStatus.Draft);
+        var handler = new GetByOrderNumberHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, 1, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<GetByOrderNumberResponse>();
+        response.Id.ShouldBe(order.Id);
+        response.Status.ShouldBe("Draft");
+        response.SubmittedAt.ShouldBeNull();
+        response.Items.ShouldBeEmpty();
+        response.ShippingAddress.ShouldBeNull();
+        response.BillingAddress.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_SubmittedOrderBelongsToCustomer_ReturnsResponse()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, status: OrderStatus.Submitted);
+        var handler = new GetByOrderNumberHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, 1, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<GetByOrderNumberResponse>();
+        response.Status.ShouldBe("Submitted");
+        response.SubmittedAt.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderWithItems_ReturnsItemsWithWidgetDetails()
+    {
+        using var db = CreateDb();
+        var widget = await SeedWidgetAsync(db);
+        var order = await SeedOrderAsync(db, customerId: 1);
+        db.OrderItems.Add(new OrderItem { OrderId = order.Id, WidgetId = widget.Id, Quantity = 3 });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = new GetByOrderNumberHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, 1, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<GetByOrderNumberResponse>();
+        response.Items.Count.ShouldBe(1);
+        response.Items[0].Sku.ShouldBe("SPR-001");
+        response.Items[0].Name.ShouldBe("Sprocket");
+        response.Items[0].Weight.ShouldBe(1.5m);
+        response.Items[0].UnitCost.ShouldBe(9.99m);
+        response.Items[0].Quantity.ShouldBe(3);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /orders/{orderNumber}` endpoint that retrieves a single order by order number for the authenticated customer
- Returns full order details: ID, status, created/submitted dates, all widgets with quantities and weight, shipping/billing addresses, estimated shipping cost
- Returns the same `404` for both non-existent orders and orders belonging to other customers (no information leakage)
- Orders of any status (Draft or Submitted) are returned

## Test plan

- [ ] `HandleAsync_OrderNotFound_ReturnsNotFound` — missing order returns `GetByOrderNumberNotFound`
- [ ] `HandleAsync_OrderBelongsToDifferentCustomer_ReturnsNotFound` — cross-customer access returns same `GetByOrderNumberNotFound` (no distinction)
- [ ] `HandleAsync_DraftOrderBelongsToCustomer_ReturnsResponse` — draft order returns full response with correct fields
- [ ] `HandleAsync_SubmittedOrderBelongsToCustomer_ReturnsResponse` — submitted order returns `SubmittedAt` populated
- [ ] `HandleAsync_OrderWithItems_ReturnsItemsWithWidgetDetails` — items include SKU, name, weight, unit cost, quantity
- [ ] Full test suite: 213 passed, 0 failed

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)