### PR TITLE
feat: implement order detail page

### DIFF
--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -10,6 +10,7 @@ using WidgetDepot.ApiService.Features.Orders.CalculateShipping;
 using WidgetDepot.ApiService.Features.Orders.CreateDraft;
 using WidgetDepot.ApiService.Features.Orders.DeleteDraft;
 using WidgetDepot.ApiService.Features.Orders.ExpireDraftOrders;
+using WidgetDepot.ApiService.Features.Orders.GetByOrderNumber;
 using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.GetDrafts;
 using WidgetDepot.ApiService.Features.Orders.GetRecentSubmitted;
@@ -71,6 +72,7 @@ builder.Services.AddScoped<UpdateDraftItemsHandler>();
 builder.Services.AddScoped<GetRecentSubmittedHandler>();
 builder.Services.AddScoped<IOrderFileWriter, OrderFileWriter>();
 builder.Services.AddScoped<ExpireDraftOrdersHandler>();
+builder.Services.AddScoped<GetByOrderNumberHandler>();
 builder.Services.AddHostedService<ExpireDraftOrdersJob>();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi

--- a/src/WidgetDepot.Web/Features/Orders/Detail/DetailModels.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Detail/DetailModels.cs
@@ -1,0 +1,48 @@
+namespace WidgetDepot.Web.Features.Orders.Detail;
+
+public record OrderDetailItem(int WidgetId, string Sku, string Name, decimal Weight, decimal UnitCost, int Quantity);
+
+public record OrderDetailAddress(
+    string RecipientName,
+    string StreetLine1,
+    string? StreetLine2,
+    string City,
+    string State,
+    string ZipCode);
+
+public record OrderDetail(
+    int Id,
+    string Status,
+    DateTime CreatedAt,
+    DateTime? SubmittedAt,
+    IReadOnlyList<OrderDetailItem> Items,
+    OrderDetailAddress? ShippingAddress,
+    OrderDetailAddress? BillingAddress,
+    decimal? ShippingEstimate);
+
+public abstract record GetOrderDetailResult
+{
+    public record Success(OrderDetail Order) : GetOrderDetailResult;
+    public record NotFound : GetOrderDetailResult;
+    public record Failure : GetOrderDetailResult;
+}
+
+internal record GetByOrderNumberItemResponse(int WidgetId, string Sku, string Name, decimal Weight, decimal UnitCost, int Quantity);
+
+internal record GetByOrderNumberAddressResponse(
+    string RecipientName,
+    string StreetLine1,
+    string? StreetLine2,
+    string City,
+    string State,
+    string ZipCode);
+
+internal record GetByOrderNumberResponse(
+    int Id,
+    string Status,
+    DateTime CreatedAt,
+    DateTime? SubmittedAt,
+    IReadOnlyList<GetByOrderNumberItemResponse> Items,
+    GetByOrderNumberAddressResponse? ShippingAddress,
+    GetByOrderNumberAddressResponse? BillingAddress,
+    decimal? ShippingEstimate);

--- a/src/WidgetDepot.Web/Features/Orders/Detail/DetailPage.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Detail/DetailPage.razor
@@ -1,0 +1,139 @@
+@page "/orders/{orderNumber:int}"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
+@using WidgetDepot.Web.Features.Orders.Detail
+@inject DetailService DetailService
+
+<PageTitle>Order #@OrderNumber</PageTitle>
+
+@if (isLoading)
+{
+    <p>Loading...</p>
+}
+else if (notFound)
+{
+    <div class="alert alert-warning">Order not found.</div>
+}
+else if (loadFailed)
+{
+    <div class="alert alert-danger">Unable to load order details. Please try again later.</div>
+}
+else if (order is not null)
+{
+    <h1>Order #@order.Id</h1>
+
+    <dl class="row mb-4">
+        <dt class="col-sm-3">Status</dt>
+        <dd class="col-sm-9">@order.Status</dd>
+        <dt class="col-sm-3">Created</dt>
+        <dd class="col-sm-9">@order.CreatedAt.ToString("d")</dd>
+        @if (order.SubmittedAt.HasValue)
+        {
+            <dt class="col-sm-3">Submitted</dt>
+            <dd class="col-sm-9">@order.SubmittedAt.Value.ToString("d")</dd>
+        }
+        @if (order.ShippingEstimate.HasValue)
+        {
+            <dt class="col-sm-3">Est. Shipping</dt>
+            <dd class="col-sm-9">@order.ShippingEstimate.Value.ToString("C")</dd>
+        }
+    </dl>
+
+    <h2>Items</h2>
+    @if (order.Items.Count == 0)
+    {
+        <p class="text-muted">No items on this order.</p>
+    }
+    else
+    {
+        <table class="table table-sm table-hover">
+            <thead class="table-dark">
+                <tr>
+                    <th>SKU</th>
+                    <th>Name</th>
+                    <th>Weight</th>
+                    <th>Unit Cost</th>
+                    <th>Qty</th>
+                    <th>Subtotal</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in order.Items)
+                {
+                    <tr>
+                        <td>@item.Sku</td>
+                        <td>@item.Name</td>
+                        <td>@item.Weight.ToString("F2")</td>
+                        <td>@item.UnitCost.ToString("C")</td>
+                        <td>@item.Quantity</td>
+                        <td>@((item.UnitCost * item.Quantity).ToString("C"))</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+
+    <div class="row mt-4">
+        @if (order.ShippingAddress is not null)
+        {
+            <div class="col-md-6">
+                <h2>Shipping Address</h2>
+                <address>
+                    @order.ShippingAddress.RecipientName<br />
+                    @order.ShippingAddress.StreetLine1<br />
+                    @if (!string.IsNullOrEmpty(order.ShippingAddress.StreetLine2))
+                    {
+                        @order.ShippingAddress.StreetLine2<br />
+                    }
+                    @order.ShippingAddress.City, @order.ShippingAddress.State @order.ShippingAddress.ZipCode
+                </address>
+            </div>
+        }
+        @if (order.BillingAddress is not null)
+        {
+            <div class="col-md-6">
+                <h2>Billing Address</h2>
+                <address>
+                    @order.BillingAddress.RecipientName<br />
+                    @order.BillingAddress.StreetLine1<br />
+                    @if (!string.IsNullOrEmpty(order.BillingAddress.StreetLine2))
+                    {
+                        @order.BillingAddress.StreetLine2<br />
+                    }
+                    @order.BillingAddress.City, @order.BillingAddress.State @order.BillingAddress.ZipCode
+                </address>
+            </div>
+        }
+    </div>
+}
+
+@code {
+    [Parameter]
+    public int OrderNumber { get; set; }
+
+    private OrderDetail? order;
+    private bool isLoading = true;
+    private bool notFound;
+    private bool loadFailed;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var result = await DetailService.GetOrderDetailAsync(OrderNumber);
+
+        switch (result)
+        {
+            case GetOrderDetailResult.Success success:
+                order = success.Order;
+                break;
+            case GetOrderDetailResult.NotFound:
+                notFound = true;
+                break;
+            default:
+                loadFailed = true;
+                break;
+        }
+
+        isLoading = false;
+    }
+}

--- a/src/WidgetDepot.Web/Features/Orders/Detail/DetailService.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Detail/DetailService.cs
@@ -1,0 +1,52 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace WidgetDepot.Web.Features.Orders.Detail;
+
+public class DetailService
+{
+    private readonly HttpClient _httpClient;
+
+    public DetailService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<GetOrderDetailResult> GetOrderDetailAsync(int orderNumber, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync($"/orders/{orderNumber}", cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return new GetOrderDetailResult.NotFound();
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var dto = await response.Content.ReadFromJsonAsync<GetByOrderNumberResponse>(cancellationToken);
+            if (dto is null)
+                return new GetOrderDetailResult.Failure();
+
+            var order = new OrderDetail(
+                dto.Id,
+                dto.Status,
+                dto.CreatedAt,
+                dto.SubmittedAt,
+                [.. dto.Items.Select(i => new OrderDetailItem(i.WidgetId, i.Sku, i.Name, i.Weight, i.UnitCost, i.Quantity))],
+                MapAddress(dto.ShippingAddress),
+                MapAddress(dto.BillingAddress),
+                dto.ShippingEstimate);
+
+            return new GetOrderDetailResult.Success(order);
+        }
+
+        return new GetOrderDetailResult.Failure();
+    }
+
+    private static OrderDetailAddress? MapAddress(GetByOrderNumberAddressResponse? address) =>
+        address is null ? null : new OrderDetailAddress(
+            address.RecipientName,
+            address.StreetLine1,
+            address.StreetLine2,
+            address.City,
+            address.State,
+            address.ZipCode);
+}

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -15,6 +15,7 @@ using WidgetDepot.Web.Features.Orders.Create;
 using WidgetDepot.Web.Features.Orders.Create.Step1;
 using WidgetDepot.Web.Features.Orders.Create.Step2;
 using WidgetDepot.Web.Features.Orders.Create.Step3;
+using WidgetDepot.Web.Features.Orders.Detail;
 using WidgetDepot.Web.Features.Orders.History;
 using WidgetDepot.Web.Features.Orders.List;
 using WidgetDepot.Web.Features.Orders.Submit;
@@ -83,6 +84,10 @@ builder.Services.AddHttpClient<Step4Service>(client =>
     .AddHttpMessageHandler<CookieForwardingHandler>();
 
 builder.Services.AddHttpClient<HistoryService>(client =>
+    client.BaseAddress = new Uri("https+http://apiservice"))
+    .AddHttpMessageHandler<CookieForwardingHandler>();
+
+builder.Services.AddHttpClient<DetailService>(client =>
     client.BaseAddress = new Uri("https+http://apiservice"))
     .AddHttpMessageHandler<CookieForwardingHandler>();
 

--- a/tests/WidgetDepot.Tests/Features/Orders/Detail/DetailServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/Detail/DetailServiceTests.cs
@@ -1,0 +1,155 @@
+using System.Net;
+using System.Text;
+
+using Shouldly;
+
+using WidgetDepot.Web.Features.Orders.Detail;
+
+namespace WidgetDepot.Tests.Features.Orders.Detail;
+
+public class DetailServiceTests
+{
+    private static DetailService CreateService(HttpStatusCode statusCode, string responseBody)
+    {
+        var handler = new FakeHttpMessageHandler(statusCode, responseBody);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        return new DetailService(httpClient);
+    }
+
+    [Fact]
+    public async Task GetOrderDetailAsync_OrderFound_ReturnsSuccess()
+    {
+        var body = """
+            {
+                "id": 42,
+                "status": "Submitted",
+                "createdAt": "2026-04-01T00:00:00",
+                "submittedAt": "2026-04-02T00:00:00",
+                "items": [],
+                "shippingAddress": null,
+                "billingAddress": null,
+                "shippingEstimate": 15.00
+            }
+            """;
+        var service = CreateService(HttpStatusCode.OK, body);
+
+        var result = await service.GetOrderDetailAsync(42, TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetOrderDetailResult.Success>();
+        success.Order.Id.ShouldBe(42);
+        success.Order.Status.ShouldBe("Submitted");
+        success.Order.SubmittedAt.ShouldNotBeNull();
+        success.Order.ShippingEstimate.ShouldBe(15.00m);
+    }
+
+    [Fact]
+    public async Task GetOrderDetailAsync_OrderNotFound_ReturnsNotFound()
+    {
+        var service = CreateService(HttpStatusCode.NotFound, "{}");
+
+        var result = await service.GetOrderDetailAsync(999, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetOrderDetailResult.NotFound>();
+    }
+
+    [Fact]
+    public async Task GetOrderDetailAsync_ServerError_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError, "{}");
+
+        var result = await service.GetOrderDetailAsync(1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetOrderDetailResult.Failure>();
+    }
+
+    [Fact]
+    public async Task GetOrderDetailAsync_Unauthorized_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.Unauthorized, "{}");
+
+        var result = await service.GetOrderDetailAsync(1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetOrderDetailResult.Failure>();
+    }
+
+    [Fact]
+    public async Task GetOrderDetailAsync_OrderWithItems_MapsItemsCorrectly()
+    {
+        var body = """
+            {
+                "id": 1,
+                "status": "Draft",
+                "createdAt": "2026-04-01T00:00:00",
+                "submittedAt": null,
+                "items": [
+                    { "widgetId": 10, "sku": "SPR-001", "name": "Sprocket", "weight": 1.5, "unitCost": 9.99, "quantity": 3 }
+                ],
+                "shippingAddress": null,
+                "billingAddress": null,
+                "shippingEstimate": null
+            }
+            """;
+        var service = CreateService(HttpStatusCode.OK, body);
+
+        var result = await service.GetOrderDetailAsync(1, TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetOrderDetailResult.Success>();
+        success.Order.Items.Count.ShouldBe(1);
+        success.Order.Items[0].Sku.ShouldBe("SPR-001");
+        success.Order.Items[0].Quantity.ShouldBe(3);
+        success.Order.Items[0].UnitCost.ShouldBe(9.99m);
+    }
+
+    [Fact]
+    public async Task GetOrderDetailAsync_OrderWithAddresses_MapsAddressesCorrectly()
+    {
+        var body = """
+            {
+                "id": 1,
+                "status": "Submitted",
+                "createdAt": "2026-04-01T00:00:00",
+                "submittedAt": "2026-04-02T00:00:00",
+                "items": [],
+                "shippingAddress": {
+                    "recipientName": "Jane Doe",
+                    "streetLine1": "123 Main St",
+                    "streetLine2": null,
+                    "city": "Springfield",
+                    "state": "IL",
+                    "zipCode": "62701"
+                },
+                "billingAddress": {
+                    "recipientName": "Jane Doe",
+                    "streetLine1": "456 Elm St",
+                    "streetLine2": "Apt 2",
+                    "city": "Shelbyville",
+                    "state": "IL",
+                    "zipCode": "62565"
+                },
+                "shippingEstimate": null
+            }
+            """;
+        var service = CreateService(HttpStatusCode.OK, body);
+
+        var result = await service.GetOrderDetailAsync(1, TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetOrderDetailResult.Success>();
+        success.Order.ShippingAddress.ShouldNotBeNull();
+        success.Order.ShippingAddress.RecipientName.ShouldBe("Jane Doe");
+        success.Order.ShippingAddress.City.ShouldBe("Springfield");
+        success.Order.BillingAddress.ShouldNotBeNull();
+        success.Order.BillingAddress.StreetLine2.ShouldBe("Apt 2");
+    }
+
+    private class FakeHttpMessageHandler(HttpStatusCode statusCode, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /orders/{orderNumber}` Blazor page at `WidgetDepot.Web/Features/Orders/Detail/`
- Calls the `GetByOrderNumber` API endpoint (from #98) to load order data
- Displays order ID, status, created date, submitted date, items with quantities, shipping/billing addresses, and estimated shipping cost
- Shows a "not found" message for orders that don't exist or belong to another customer
- Unauthenticated visitors are redirected to login via `[Authorize]`

## Test plan

- [ ] `DetailServiceTests` — 6 unit tests covering success, not-found, server error, unauthorized, items mapping, and address mapping
- [ ] All 219 existing tests continue to pass
- [ ] Build succeeds with 0 warnings

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)