### PR TITLE
feat: implement order lookup form (#100)

### DIFF
--- a/src/WidgetDepot.Web/Components/Layout/NavMenu.razor
+++ b/src/WidgetDepot.Web/Components/Layout/NavMenu.razor
@@ -42,6 +42,11 @@
                     </NavLink>
                 </div>
                 <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="orders/lookup">
+                        <span class="bi bi-search" aria-hidden="true"></span> Order Lookup
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
                     <NavLink class="nav-link" href="accounts/profile">
                         <span class="bi bi-person-fill" aria-hidden="true"></span> Profile
                     </NavLink>

--- a/src/WidgetDepot.Web/Features/Orders/Detail/DetailModels.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Detail/DetailModels.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace WidgetDepot.Web.Features.Orders.Detail;
 
 public record OrderDetailItem(int WidgetId, string Sku, string Name, decimal Weight, decimal UnitCost, int Quantity);
@@ -25,6 +27,12 @@ public abstract record GetOrderDetailResult
     public record Success(OrderDetail Order) : GetOrderDetailResult;
     public record NotFound : GetOrderDetailResult;
     public record Failure : GetOrderDetailResult;
+}
+
+public class LookupFormModel
+{
+    [Required(ErrorMessage = "Order number is required.")]
+    public string? OrderNumber { get; set; }
 }
 
 internal record GetByOrderNumberItemResponse(int WidgetId, string Sku, string Name, decimal Weight, decimal UnitCost, int Quantity);

--- a/src/WidgetDepot.Web/Features/Orders/Detail/DetailModels.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Detail/DetailModels.cs
@@ -32,7 +32,8 @@ public abstract record GetOrderDetailResult
 public class LookupFormModel
 {
     [Required(ErrorMessage = "Order number is required.")]
-    public string? OrderNumber { get; set; }
+    [Range(1, int.MaxValue, ErrorMessage = "Order number must be a positive number.")]
+    public int? OrderNumber { get; set; }
 }
 
 internal record GetByOrderNumberItemResponse(int WidgetId, string Sku, string Name, decimal Weight, decimal UnitCost, int Quantity);

--- a/src/WidgetDepot.Web/Features/Orders/Detail/LookupPage.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Detail/LookupPage.razor
@@ -16,7 +16,7 @@
 
             <div class="mb-3">
                 <label class="form-label" for="orderNumber">Order Number</label>
-                <InputText id="orderNumber" class="form-control" @bind-Value="form.OrderNumber" />
+                <InputNumber id="orderNumber" class="form-control" @bind-Value="form.OrderNumber" />
                 <ValidationMessage For="() => form.OrderNumber" class="text-danger" />
             </div>
 

--- a/src/WidgetDepot.Web/Features/Orders/Detail/LookupPage.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Detail/LookupPage.razor
@@ -1,0 +1,35 @@
+@page "/orders/lookup"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
+@using WidgetDepot.Web.Features.Orders.Detail
+@inject NavigationManager NavigationManager
+
+<PageTitle>Order Lookup</PageTitle>
+
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <h1>Order Lookup</h1>
+
+        <EditForm Model="form" OnValidSubmit="HandleSubmit">
+            <DataAnnotationsValidator />
+
+            <div class="mb-3">
+                <label class="form-label" for="orderNumber">Order Number</label>
+                <InputText id="orderNumber" class="form-control" @bind-Value="form.OrderNumber" />
+                <ValidationMessage For="() => form.OrderNumber" class="text-danger" />
+            </div>
+
+            <button type="submit" class="btn btn-primary">Look Up</button>
+        </EditForm>
+    </div>
+</div>
+
+@code {
+    private readonly LookupFormModel form = new();
+
+    private void HandleSubmit()
+    {
+        NavigationManager.NavigateTo($"/orders/{form.OrderNumber}");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new Blazor page at `/orders/lookup` in the `Detail` feature slice
- Authenticated customers can enter an order number and are redirected to `/orders/{orderNumber}`
- Unauthenticated visitors are redirected to login via the `[Authorize]` attribute
- `LookupFormModel` with `[Required]` validation added to `DetailModels.cs`
- No service registration needed — this page only uses `NavigationManager`
- No unit tests added — the page contains no business logic beyond Blazor navigation; the existing project does not use bUnit for component testing

## Test plan

- [ ] Navigate to `/orders/lookup` while unauthenticated → redirected to login
- [ ] Navigate to `/orders/lookup` while authenticated → lookup form is shown
- [ ] Submit the form without entering a value → validation message appears
- [ ] Enter an order number and submit → redirected to `/orders/{enteredNumber}`

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)