### PR TITLE
feat: add shipping and billing address columns to Customer

### DIFF
--- a/docs/milestone-02/09-profile-saved-addresses.md
+++ b/docs/milestone-02/09-profile-saved-addresses.md
@@ -1,3 +1,10 @@
+---
+status: split
+milestone: 2
+github_issue: 104
+task_issues: [105, 106]
+---
+
 # Profile: saved shipping and billing addresses
 
 ## User Story

--- a/src/WidgetDepot.ApiService/Data/AppDbContext.cs
+++ b/src/WidgetDepot.ApiService/Data/AppDbContext.cs
@@ -34,6 +34,28 @@ public class AppDbContext : DbContext
         modelBuilder.Entity<Customer>(entity =>
         {
             entity.HasIndex(c => c.Email).IsUnique();
+
+            entity.OwnsOne(c => c.ShippingAddress, a =>
+            {
+                a.Property(x => x.RecipientName).HasColumnName("ShippingRecipientName").HasColumnType("text");
+                a.Property(x => x.StreetLine1).HasColumnName("ShippingStreetLine1").HasColumnType("text");
+                a.Property(x => x.StreetLine2).HasColumnName("ShippingStreetLine2").HasColumnType("text");
+                a.Property(x => x.City).HasColumnName("ShippingCity").HasColumnType("text");
+                a.Property(x => x.State).HasColumnName("ShippingState").HasColumnType("text");
+                a.Property(x => x.ZipCode).HasColumnName("ShippingZipCode").HasColumnType("text");
+            });
+            entity.Navigation(c => c.ShippingAddress).IsRequired(false);
+
+            entity.OwnsOne(c => c.BillingAddress, a =>
+            {
+                a.Property(x => x.RecipientName).HasColumnName("BillingRecipientName").HasColumnType("text");
+                a.Property(x => x.StreetLine1).HasColumnName("BillingStreetLine1").HasColumnType("text");
+                a.Property(x => x.StreetLine2).HasColumnName("BillingStreetLine2").HasColumnType("text");
+                a.Property(x => x.City).HasColumnName("BillingCity").HasColumnType("text");
+                a.Property(x => x.State).HasColumnName("BillingState").HasColumnType("text");
+                a.Property(x => x.ZipCode).HasColumnName("BillingZipCode").HasColumnType("text");
+            });
+            entity.Navigation(c => c.BillingAddress).IsRequired(false);
         });
 
         modelBuilder.Entity<OrderItem>(entity =>

--- a/src/WidgetDepot.ApiService/Data/Customer.cs
+++ b/src/WidgetDepot.ApiService/Data/Customer.cs
@@ -8,4 +8,6 @@ public class Customer
     public string Email { get; set; } = string.Empty;
     public string PasswordHash { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
+    public Address? ShippingAddress { get; set; }
+    public Address? BillingAddress { get; set; }
 }

--- a/src/WidgetDepot.ApiService/Data/Migrations/20260516093314_AddCustomerAddresses.Designer.cs
+++ b/src/WidgetDepot.ApiService/Data/Migrations/20260516093314_AddCustomerAddresses.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WidgetDepot.ApiService.Data;
@@ -11,9 +12,11 @@ using WidgetDepot.ApiService.Data;
 namespace WidgetDepot.ApiService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260516093314_AddCustomerAddresses")]
+    partial class AddCustomerAddresses
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WidgetDepot.ApiService/Data/Migrations/20260516093314_AddCustomerAddresses.cs
+++ b/src/WidgetDepot.ApiService/Data/Migrations/20260516093314_AddCustomerAddresses.cs
@@ -1,0 +1,138 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WidgetDepot.ApiService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCustomerAddresses : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BillingCity",
+                table: "Customers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "BillingRecipientName",
+                table: "Customers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "BillingState",
+                table: "Customers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "BillingStreetLine1",
+                table: "Customers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "BillingStreetLine2",
+                table: "Customers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "BillingZipCode",
+                table: "Customers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShippingCity",
+                table: "Customers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShippingRecipientName",
+                table: "Customers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShippingState",
+                table: "Customers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShippingStreetLine1",
+                table: "Customers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShippingStreetLine2",
+                table: "Customers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShippingZipCode",
+                table: "Customers",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BillingCity",
+                table: "Customers");
+
+            migrationBuilder.DropColumn(
+                name: "BillingRecipientName",
+                table: "Customers");
+
+            migrationBuilder.DropColumn(
+                name: "BillingState",
+                table: "Customers");
+
+            migrationBuilder.DropColumn(
+                name: "BillingStreetLine1",
+                table: "Customers");
+
+            migrationBuilder.DropColumn(
+                name: "BillingStreetLine2",
+                table: "Customers");
+
+            migrationBuilder.DropColumn(
+                name: "BillingZipCode",
+                table: "Customers");
+
+            migrationBuilder.DropColumn(
+                name: "ShippingCity",
+                table: "Customers");
+
+            migrationBuilder.DropColumn(
+                name: "ShippingRecipientName",
+                table: "Customers");
+
+            migrationBuilder.DropColumn(
+                name: "ShippingState",
+                table: "Customers");
+
+            migrationBuilder.DropColumn(
+                name: "ShippingStreetLine1",
+                table: "Customers");
+
+            migrationBuilder.DropColumn(
+                name: "ShippingStreetLine2",
+                table: "Customers");
+
+            migrationBuilder.DropColumn(
+                name: "ShippingZipCode",
+                table: "Customers");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds nullable `ShippingAddress` and `BillingAddress` owned-entity properties to the `Customer` entity
- Configures both as owned types in `AppDbContext` using the same column-naming pattern as `Order`
- Generates migration `AddCustomerAddresses` with 12 nullable `text` columns on the `Customers` table

## Test plan

- [x] `dotnet build` succeeds with no warnings
- [x] `dotnet test` passes (219 passed, 0 failed)
- [x] Verify migration applies cleanly against the local database

Closes #105