### PR TITLE
feat: pre-fill order wizard step 2 addresses from customer profile

### DIFF
--- a/docs/milestone-02/10-order-wizard-address-prefill.md
+++ b/docs/milestone-02/10-order-wizard-address-prefill.md
@@ -1,3 +1,10 @@
+---
+status: shared
+milestone: 2
+github_issue: 109
+task_issues: []
+---
+
 # Order wizard: pre-fill addresses from profile
 
 ## User Story

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Models.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Models.cs
@@ -134,6 +134,18 @@ public record AddressRequest(
 
 public record SaveAddressesRequest(AddressRequest ShippingAddress, AddressRequest BillingAddress);
 
+public record ProfileAddressData(
+    string RecipientName,
+    string StreetLine1,
+    string? StreetLine2,
+    string City,
+    string State,
+    string ZipCode);
+
+public record ProfileAddressesResponse(
+    ProfileAddressData? ShippingAddress,
+    ProfileAddressData? BillingAddress);
+
 public abstract record SaveAddressesResult
 {
     public record Success : SaveAddressesResult;

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
@@ -166,6 +166,45 @@
         {
             CopyFromOrder(order);
         }
+
+        await PrefillFromProfileAsync();
+    }
+
+    private async Task PrefillFromProfileAsync()
+    {
+        var shippingEmpty = string.IsNullOrEmpty(form.ShippingStreetLine1);
+        var billingEmpty = string.IsNullOrEmpty(form.BillingStreetLine1);
+
+        if (!shippingEmpty && !billingEmpty)
+        {
+            return;
+        }
+
+        var profileResult = await Step2Service.GetProfileAddressesAsync();
+        if (profileResult is not GetProfileAddressesResult.Success profileSuccess)
+        {
+            return;
+        }
+
+        if (shippingEmpty && profileSuccess.Profile.ShippingAddress is { } shipping)
+        {
+            form.ShippingRecipientName = shipping.RecipientName;
+            form.ShippingStreetLine1 = shipping.StreetLine1;
+            form.ShippingStreetLine2 = shipping.StreetLine2;
+            form.ShippingCity = shipping.City;
+            form.ShippingState = shipping.State;
+            form.ShippingZipCode = shipping.ZipCode;
+        }
+
+        if (billingEmpty && profileSuccess.Profile.BillingAddress is { } billing)
+        {
+            form.BillingRecipientName = billing.RecipientName;
+            form.BillingStreetLine1 = billing.StreetLine1;
+            form.BillingStreetLine2 = billing.StreetLine2;
+            form.BillingCity = billing.City;
+            form.BillingState = billing.State;
+            form.BillingZipCode = billing.ZipCode;
+        }
     }
 
     private void CopyFromOrder(GetDraftOrderResponse order)

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Service.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Service.cs
@@ -11,6 +11,12 @@ public abstract record GetDraftOrderResult
     public record Failure : GetDraftOrderResult;
 }
 
+public abstract record GetProfileAddressesResult
+{
+    public record Success(ProfileAddressesResponse Profile) : GetProfileAddressesResult;
+    public record Failure : GetProfileAddressesResult;
+}
+
 public class Step2Service
 {
     private readonly HttpClient _httpClient;
@@ -67,6 +73,21 @@ public class Step2Service
             HttpStatusCode.Forbidden => new SaveAddressesResult.Forbidden(),
             _ => new SaveAddressesResult.Failure()
         };
+    }
+
+    public async Task<GetProfileAddressesResult> GetProfileAddressesAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync("/accounts/profile", cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var profile = await response.Content.ReadFromJsonAsync<ProfileAddressesResponse>(cancellationToken);
+            return profile is null
+                ? new GetProfileAddressesResult.Failure()
+                : new GetProfileAddressesResult.Success(profile);
+        }
+
+        return new GetProfileAddressesResult.Failure();
     }
 
     private static string? NullIfEmpty(string? value) =>

--- a/tests/WidgetDepot.Tests/Features/Orders/Create/Step2/Step2ServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/Create/Step2/Step2ServiceTests.cs
@@ -135,6 +135,48 @@ public class Step2ServiceTests
         capturedBody.ShouldContain("\"streetLine2\":null");
     }
 
+    [Fact]
+    public async Task GetProfileAddressesAsync_OkResponseWithShippingAddress_ReturnsSuccessWithShippingAddress()
+    {
+        var json = """{"shippingAddress":{"recipientName":"Alice Smith","streetLine1":"123 Main St","streetLine2":null,"city":"Springfield","state":"IL","zipCode":"62701"},"billingAddress":null}""";
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK, responseContent: json);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        var service = new Step2Service(httpClient);
+
+        var result = await service.GetProfileAddressesAsync(TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetProfileAddressesResult.Success>();
+        success.Profile.ShippingAddress.ShouldNotBeNull();
+        success.Profile.ShippingAddress.RecipientName.ShouldBe("Alice Smith");
+        success.Profile.ShippingAddress.StreetLine1.ShouldBe("123 Main St");
+        success.Profile.BillingAddress.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetProfileAddressesAsync_OkResponseWithNoAddresses_ReturnsSuccessWithNullAddresses()
+    {
+        var json = """{"shippingAddress":null,"billingAddress":null}""";
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK, responseContent: json);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        var service = new Step2Service(httpClient);
+
+        var result = await service.GetProfileAddressesAsync(TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetProfileAddressesResult.Success>();
+        success.Profile.ShippingAddress.ShouldBeNull();
+        success.Profile.BillingAddress.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetProfileAddressesAsync_NonSuccessResponse_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError);
+
+        var result = await service.GetProfileAddressesAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetProfileAddressesResult.Failure>();
+    }
+
     private class FakeHttpMessageHandler : HttpMessageHandler
     {
         private readonly HttpStatusCode _statusCode;


### PR DESCRIPTION
## Summary

- Added `GetProfileAddressesAsync` to `Step2Service` to fetch saved addresses from the customer profile via `GET /accounts/profile`
- Step 2 page now pre-fills empty shipping/billing address sections from the customer's profile on initialization
- Sections already populated from a saved draft order (returning to step 2) are not overwritten by profile values
- If only one address type is saved on the profile, only that section is pre-filled; the other remains empty
- 3 unit tests added for `GetProfileAddressesAsync`

## Test plan

- [x] Log in as a customer with saved shipping and billing addresses on their profile; confirm step 2 pre-fills both sections
- [x] Log in as a customer with only a shipping address saved; confirm only shipping pre-fills
- [x] Log in as a customer with no saved addresses; confirm step 2 fields remain empty
- [x] Edit a pre-filled field and click Continue; confirm the edited value (not profile default) is stored on the order
- [x] Complete step 2, navigate back from step 3 to step 2; confirm the previously entered values are shown (not re-fetched from profile)
- [x] All tests pass: `dotnet test`

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)