### PR TITLE
feat: save order wizard step 2 addresses to customer profile

### DIFF
--- a/docs/milestone-02/11-order-wizard-update-profile-addresses.md
+++ b/docs/milestone-02/11-order-wizard-update-profile-addresses.md
@@ -1,7 +1,7 @@
 ---
 status: ready
 milestone: 2
-github_issue:
+github_issue: 111
 task_issues: []
 ---
 
@@ -15,8 +15,7 @@ task_issues: []
 
 ## Background
 
-This story is the complement to story 10 (pre-fill addresses from profile). Story 10 explicitly
-scoped out saving wizard address edits back to the profile; this story adds that capability.
+This story is the complement to story 10 (pre-fill addresses from profile). 
 
 When a customer reaches step 2 of the order wizard, two "Save to profile" checkboxes appear —
 one for shipping, one for billing. Both are pre-checked by default. If the customer clicks

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Models.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Models.cs
@@ -47,6 +47,9 @@ public class Step2FormModel
     [Required(ErrorMessage = "ZIP code is required.")]
     [RegularExpression(@"^\d{5}(-\d{4})?$", ErrorMessage = "ZIP code must be in 5-digit (12345) or ZIP+4 (12345-6789) format.")]
     public string BillingZipCode { get; set; } = string.Empty;
+
+    public bool SaveShippingToProfile { get; set; } = true;
+    public bool SaveBillingToProfile { get; set; } = true;
 }
 
 public static class UsStates
@@ -152,4 +155,17 @@ public abstract record SaveAddressesResult
     public record NotFound : SaveAddressesResult;
     public record Forbidden : SaveAddressesResult;
     public record Failure : SaveAddressesResult;
+}
+
+public record FullProfileData(
+    string FirstName,
+    string LastName,
+    string Email,
+    ProfileAddressData? ShippingAddress,
+    ProfileAddressData? BillingAddress);
+
+public abstract record SaveProfileAddressesResult
+{
+    public record Success : SaveProfileAddressesResult;
+    public record Failure : SaveProfileAddressesResult;
 }

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Page.razor
@@ -63,6 +63,11 @@
                     <ValidationMessage For="() => form.ShippingZipCode" class="text-danger" />
                 </div>
             </div>
+
+            <div class="form-check mb-3">
+                <InputCheckbox id="saveShippingToProfile" class="form-check-input" @bind-Value="form.SaveShippingToProfile" />
+                <label class="form-check-label" for="saveShippingToProfile">Save to profile</label>
+            </div>
         </div>
 
         <div class="col-md-6">
@@ -116,6 +121,11 @@
                     <InputText id="billingZipCode" class="form-control" @bind-Value="form.BillingZipCode" />
                     <ValidationMessage For="() => form.BillingZipCode" class="text-danger" />
                 </div>
+            </div>
+
+            <div class="form-check mb-3">
+                <InputCheckbox id="saveBillingToProfile" class="form-check-input" @bind-Value="form.SaveBillingToProfile" />
+                <label class="form-check-label" for="saveBillingToProfile">Save to profile</label>
             </div>
         </div>
     </div>
@@ -269,6 +279,14 @@
         NavigationManager.NavigateTo($"/orders/{OrderId}/step1");
     }
 
+    private async Task SaveProfileAddressesIfNeededAsync()
+    {
+        if (!form.SaveShippingToProfile && !form.SaveBillingToProfile)
+            return;
+
+        await Step2Service.SaveProfileAddressesAsync(form, form.SaveShippingToProfile, form.SaveBillingToProfile);
+    }
+
     private async Task HandleContinue()
     {
         isSubmitting = true;
@@ -282,6 +300,7 @@
             {
                 case SaveAddressesResult.Success:
                     SaveToState();
+                    await SaveProfileAddressesIfNeededAsync();
                     NavigationManager.NavigateTo($"/orders/{OrderId}/shipping");
                     break;
                 case SaveAddressesResult.NotFound:

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Service.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step2/Step2Service.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
 
+using Microsoft.Extensions.Logging;
+
 namespace WidgetDepot.Web.Features.Orders.Create.Step2;
 
 public abstract record GetDraftOrderResult
@@ -20,10 +22,12 @@ public abstract record GetProfileAddressesResult
 public class Step2Service
 {
     private readonly HttpClient _httpClient;
+    private readonly ILogger<Step2Service> _logger;
 
-    public Step2Service(HttpClient httpClient)
+    public Step2Service(HttpClient httpClient, ILogger<Step2Service> logger)
     {
         _httpClient = httpClient;
+        _logger = logger;
     }
 
     public async Task<GetDraftOrderResult> GetDraftOrderAsync(int orderId, CancellationToken cancellationToken = default)
@@ -89,6 +93,46 @@ public class Step2Service
 
         return new GetProfileAddressesResult.Failure();
     }
+
+    public async Task<SaveProfileAddressesResult> SaveProfileAddressesAsync(
+        Step2FormModel form,
+        bool saveShipping,
+        bool saveBilling,
+        CancellationToken cancellationToken = default)
+    {
+        var getResponse = await _httpClient.GetAsync("/accounts/profile", cancellationToken);
+        if (!getResponse.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("Failed to get profile for address update. StatusCode: {StatusCode}", getResponse.StatusCode);
+            return new SaveProfileAddressesResult.Failure();
+        }
+
+        var profile = await getResponse.Content.ReadFromJsonAsync<FullProfileData>(cancellationToken);
+        if (profile is null)
+        {
+            _logger.LogWarning("Failed to deserialize profile response for address update.");
+            return new SaveProfileAddressesResult.Failure();
+        }
+
+        var shippingAddress = saveShipping ? ToProfileAddress(form, shipping: true) : profile.ShippingAddress;
+        var billingAddress = saveBilling ? ToProfileAddress(form, shipping: false) : profile.BillingAddress;
+
+        var request = new FullProfileData(profile.FirstName, profile.LastName, profile.Email, shippingAddress, billingAddress);
+        var putResponse = await _httpClient.PutAsJsonAsync("/accounts/profile", request, cancellationToken);
+
+        if (!putResponse.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("Failed to update profile addresses. StatusCode: {StatusCode}", putResponse.StatusCode);
+            return new SaveProfileAddressesResult.Failure();
+        }
+
+        return new SaveProfileAddressesResult.Success();
+    }
+
+    private static ProfileAddressData ToProfileAddress(Step2FormModel form, bool shipping) =>
+        shipping
+            ? new ProfileAddressData(form.ShippingRecipientName, form.ShippingStreetLine1, NullIfEmpty(form.ShippingStreetLine2), form.ShippingCity, form.ShippingState, form.ShippingZipCode)
+            : new ProfileAddressData(form.BillingRecipientName, form.BillingStreetLine1, NullIfEmpty(form.BillingStreetLine2), form.BillingCity, form.BillingState, form.BillingZipCode);
 
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value;

--- a/tests/WidgetDepot.Tests/Features/Orders/Create/Step2/Step2ServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/Create/Step2/Step2ServiceTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Text;
 
+using Microsoft.Extensions.Logging.Abstractions;
+
 using Shouldly;
 
 using WidgetDepot.Web.Features.Orders.Create.Step2;
@@ -13,7 +15,13 @@ public class Step2ServiceTests
     {
         var handler = new FakeHttpMessageHandler(statusCode);
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
-        return new Step2Service(httpClient);
+        return new Step2Service(httpClient, NullLogger<Step2Service>.Instance);
+    }
+
+    private static Step2Service CreateServiceWithHandler(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
+        return new Step2Service(httpClient, NullLogger<Step2Service>.Instance);
     }
 
     private static Step2FormModel ValidForm() => new()
@@ -38,7 +46,7 @@ public class Step2ServiceTests
         var json = """{"id":1,"status":"Draft","items":[],"shippingAddress":null,"billingAddress":null}""";
         var handler = new FakeHttpMessageHandler(HttpStatusCode.OK, responseContent: json);
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
-        var service = new Step2Service(httpClient);
+        var service = new Step2Service(httpClient, NullLogger<Step2Service>.Instance);
 
         var result = await service.GetDraftOrderAsync(1, TestContext.Current.CancellationToken);
 
@@ -124,7 +132,7 @@ public class Step2ServiceTests
         string? capturedBody = null;
         var handler = new FakeHttpMessageHandler(HttpStatusCode.NoContent, body => capturedBody = body);
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
-        var service = new Step2Service(httpClient);
+        var service = new Step2Service(httpClient, NullLogger<Step2Service>.Instance);
 
         var form = ValidForm();
         form.ShippingStreetLine2 = "   ";
@@ -141,7 +149,7 @@ public class Step2ServiceTests
         var json = """{"shippingAddress":{"recipientName":"Alice Smith","streetLine1":"123 Main St","streetLine2":null,"city":"Springfield","state":"IL","zipCode":"62701"},"billingAddress":null}""";
         var handler = new FakeHttpMessageHandler(HttpStatusCode.OK, responseContent: json);
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
-        var service = new Step2Service(httpClient);
+        var service = new Step2Service(httpClient, NullLogger<Step2Service>.Instance);
 
         var result = await service.GetProfileAddressesAsync(TestContext.Current.CancellationToken);
 
@@ -158,7 +166,7 @@ public class Step2ServiceTests
         var json = """{"shippingAddress":null,"billingAddress":null}""";
         var handler = new FakeHttpMessageHandler(HttpStatusCode.OK, responseContent: json);
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test") };
-        var service = new Step2Service(httpClient);
+        var service = new Step2Service(httpClient, NullLogger<Step2Service>.Instance);
 
         var result = await service.GetProfileAddressesAsync(TestContext.Current.CancellationToken);
 
@@ -175,6 +183,108 @@ public class Step2ServiceTests
         var result = await service.GetProfileAddressesAsync(TestContext.Current.CancellationToken);
 
         result.ShouldBeOfType<GetProfileAddressesResult.Failure>();
+    }
+
+    [Fact]
+    public async Task SaveProfileAddressesAsync_GetAndPutSucceed_ReturnsSuccess()
+    {
+        var profileJson = """{"firstName":"Alice","lastName":"Smith","email":"alice@example.com","shippingAddress":null,"billingAddress":null}""";
+        var handler = new SequencedHttpMessageHandler(
+            (HttpStatusCode.OK, profileJson, null),
+            (HttpStatusCode.OK, "{}", null));
+        var service = CreateServiceWithHandler(handler);
+
+        var result = await service.SaveProfileAddressesAsync(ValidForm(), saveShipping: true, saveBilling: true, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SaveProfileAddressesResult.Success>();
+    }
+
+    [Fact]
+    public async Task SaveProfileAddressesAsync_GetFails_ReturnsFailure()
+    {
+        var handler = new SequencedHttpMessageHandler(
+            (HttpStatusCode.InternalServerError, "{}", null));
+        var service = CreateServiceWithHandler(handler);
+
+        var result = await service.SaveProfileAddressesAsync(ValidForm(), saveShipping: true, saveBilling: false, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SaveProfileAddressesResult.Failure>();
+    }
+
+    [Fact]
+    public async Task SaveProfileAddressesAsync_PutFails_ReturnsFailure()
+    {
+        var profileJson = """{"firstName":"Alice","lastName":"Smith","email":"alice@example.com","shippingAddress":null,"billingAddress":null}""";
+        var handler = new SequencedHttpMessageHandler(
+            (HttpStatusCode.OK, profileJson, null),
+            (HttpStatusCode.InternalServerError, "{}", null));
+        var service = CreateServiceWithHandler(handler);
+
+        var result = await service.SaveProfileAddressesAsync(ValidForm(), saveShipping: true, saveBilling: true, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SaveProfileAddressesResult.Failure>();
+    }
+
+    [Fact]
+    public async Task SaveProfileAddressesAsync_ShippingChecked_SendsShippingFromForm()
+    {
+        var profileJson = """{"firstName":"Alice","lastName":"Smith","email":"alice@example.com","shippingAddress":null,"billingAddress":null}""";
+        string? capturedBody = null;
+        var handler = new SequencedHttpMessageHandler(
+            (HttpStatusCode.OK, profileJson, null),
+            (HttpStatusCode.OK, "{}", body => capturedBody = body));
+        var service = CreateServiceWithHandler(handler);
+
+        var form = ValidForm();
+        await service.SaveProfileAddressesAsync(form, saveShipping: true, saveBilling: false, TestContext.Current.CancellationToken);
+
+        capturedBody.ShouldNotBeNull();
+        capturedBody.ShouldContain(form.ShippingRecipientName);
+        capturedBody.ShouldContain(form.ShippingStreetLine1);
+    }
+
+    [Fact]
+    public async Task SaveProfileAddressesAsync_BillingUnchecked_SendsBillingFromProfile()
+    {
+        var existingBillingJson = """{"recipientName":"Existing Recipient","streetLine1":"999 Profile St","streetLine2":null,"city":"OldCity","state":"TX","zipCode":"75001"}""";
+        var profileJson = $$"""{"firstName":"Alice","lastName":"Smith","email":"alice@example.com","shippingAddress":null,"billingAddress":{{existingBillingJson}}}""";
+        string? capturedBody = null;
+        var handler = new SequencedHttpMessageHandler(
+            (HttpStatusCode.OK, profileJson, null),
+            (HttpStatusCode.OK, "{}", body => capturedBody = body));
+        var service = CreateServiceWithHandler(handler);
+
+        await service.SaveProfileAddressesAsync(ValidForm(), saveShipping: true, saveBilling: false, TestContext.Current.CancellationToken);
+
+        capturedBody.ShouldNotBeNull();
+        capturedBody.ShouldContain("Existing Recipient");
+        capturedBody.ShouldContain("999 Profile St");
+    }
+
+    private class SequencedHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Queue<(HttpStatusCode StatusCode, string Content, Action<string>? BodyCapture)> _responses;
+
+        public SequencedHttpMessageHandler(params (HttpStatusCode StatusCode, string Content, Action<string>? BodyCapture)[] responses)
+        {
+            _responses = new Queue<(HttpStatusCode, string, Action<string>?)>(responses);
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var (statusCode, content, bodyCapture) = _responses.Dequeue();
+
+            if (bodyCapture is not null && request.Content is not null)
+            {
+                var body = await request.Content.ReadAsStringAsync(cancellationToken);
+                bodyCapture(body);
+            }
+
+            return new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(content, Encoding.UTF8, "application/json")
+            };
+        }
     }
 
     private class FakeHttpMessageHandler : HttpMessageHandler


### PR DESCRIPTION
## Summary

- Adds "Save to profile" checkboxes (pre-checked by default) below the shipping and billing address fields on order wizard step 2
- On Continue, each checked address is immediately written to the customer profile via `PUT /accounts/profile` (GET current profile first to preserve name/email and unchanged address)
- Profile save is best-effort: failures are logged via `ILogger<Step2Service>` and the wizard proceeds to step 3 regardless

## Changes

- `Step2FormModel`: added `SaveShippingToProfile` and `SaveBillingToProfile` (both default `true`)
- `Step2Models.cs`: added `FullProfileData` record (for GET/PUT profile) and `SaveProfileAddressesResult` discriminated union
- `Step2Service`: added `ILogger<Step2Service>`, `SaveProfileAddressesAsync`, and `ToProfileAddress` helper
- `Step2Page.razor`: added two `InputCheckbox` controls and `SaveProfileAddressesIfNeededAsync` called in `HandleContinue`
- `Step2ServiceTests`: updated constructor calls for `ILogger`, added 5 new tests covering success, GET failure, PUT failure, shipping-from-form, and billing-unchanged-from-profile scenarios

## Test plan
- [x] All 17 Step2 unit tests pass (`dotnet test --filter Step2`)
- [x] Step 2 shows "Save to profile" checkbox below shipping and below billing fields, both pre-checked
- [x] Clicking Continue with both checked saves addresses to profile
- [x] Unchecking a checkbox and clicking Continue leaves that profile address unchanged
- [x] A simulated profile save failure does not block navigation to step 3

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)