### PR TITLE
fix: enforce Draft status check when loading order for step 1 edit

### DIFF
--- a/docs/milestone-02/12-edit-draft-order-widgets.md
+++ b/docs/milestone-02/12-edit-draft-order-widgets.md
@@ -41,7 +41,7 @@ orders list with "Resume" action), and the step 2 page from story 02 to accept a
 
 ## Acceptance Criteria
 
-- [ ] Step 1 (edit mode) is only reachable for orders in `Draft` status belonging to the authenticated customer; any other attempt returns an appropriate error
+- [x] Step 1 (edit mode) is only reachable for orders in `Draft` status belonging to the authenticated customer; any other attempt returns an appropriate error
 - [ ] Previously selected widgets and quantities are pre-populated when the customer arrives at step 1 via "Resume"
 - [ ] The customer can add a widget with a quantity, adjust quantity, and remove a widget from the order
 - [ ] A summary of selected widgets and their quantities is visible at all times during this step

--- a/src/WidgetDepot.ApiService/Features/Orders/GetDraftOrder/GetDraftOrderEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/GetDraftOrder/GetDraftOrderEndpoint.cs
@@ -21,6 +21,7 @@ public static class GetDraftOrderEndpoint
             {
                 GetDraftOrderError.OrderNotFound => Results.NotFound(),
                 GetDraftOrderError.Forbidden => Results.Forbid(),
+                GetDraftOrderError.NotDraft => Results.Conflict(),
                 GetDraftOrderResponse response => Results.Ok(response),
                 _ => Results.Problem(statusCode: 500)
             };

--- a/src/WidgetDepot.ApiService/Features/Orders/GetDraftOrder/GetDraftOrderHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/GetDraftOrder/GetDraftOrderHandler.cs
@@ -26,6 +26,7 @@ public abstract record GetDraftOrderError
 {
     public record OrderNotFound : GetDraftOrderError;
     public record Forbidden : GetDraftOrderError;
+    public record NotDraft : GetDraftOrderError;
 }
 
 public class GetDraftOrderHandler(AppDbContext db)
@@ -42,6 +43,9 @@ public class GetDraftOrderHandler(AppDbContext db)
 
         if (order.CustomerId != customerId)
             return new GetDraftOrderError.Forbidden();
+
+        if (order.Status != OrderStatus.Draft)
+            return new GetDraftOrderError.NotDraft();
 
         return new GetDraftOrderResponse(
             order.Id,

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Models.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Models.cs
@@ -50,5 +50,6 @@ public abstract record GetDraftStep1Result
     public record Success(GetDraftStep1Response Order) : GetDraftStep1Result;
     public record NotFound : GetDraftStep1Result;
     public record Forbidden : GetDraftStep1Result;
+    public record NotDraft : GetDraftStep1Result;
     public record Failure : GetDraftStep1Result;
 }

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Page.razor
@@ -143,6 +143,12 @@
         {
             var result = await Step1Service.GetDraftOrderAsync(OrderId);
 
+            if (result is GetDraftStep1Result.NotDraft)
+            {
+                errorMessage = "This order is no longer a draft and cannot be edited.";
+                return;
+            }
+
             if (result is not GetDraftStep1Result.Success success)
             {
                 errorMessage = "The order could not be found or you do not have permission to view it.";

--- a/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Service.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Service.cs
@@ -20,6 +20,7 @@ public class Step1Service(HttpClient httpClient)
         {
             HttpStatusCode.NotFound => new GetDraftStep1Result.NotFound(),
             HttpStatusCode.Forbidden => new GetDraftStep1Result.Forbidden(),
+            HttpStatusCode.Conflict => new GetDraftStep1Result.NotDraft(),
             _ => new GetDraftStep1Result.Failure()
         };
     }

--- a/tests/WidgetDepot.Tests/Features/Orders/GetDraftOrder/GetDraftOrderHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/GetDraftOrder/GetDraftOrderHandlerTests.cs
@@ -71,6 +71,20 @@ public class GetDraftOrderHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_OrderIsNotInDraftStatus_ReturnsNotDraft()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1);
+        order.Status = OrderStatus.Submitted;
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = new GetDraftOrderHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<GetDraftOrderError.NotDraft>();
+    }
+
+    [Fact]
     public async Task HandleAsync_OrderExistsAndBelongsToCustomer_ReturnsResponse()
     {
         using var db = CreateDb();


### PR DESCRIPTION
## Summary

- `GetDraftOrderHandler` was missing a Draft status check — a customer could load step 1 for a submitted or cancelled order (they couldn't save changes since `UpdateDraftItemsHandler` already validates status, but the page would open)
- Adds `GetDraftOrderError.NotDraft` (mapped to **409 Conflict** in the endpoint, matching the pattern used by `UpdateDraftItemsEndpoint`)
- `Step1Service` maps 409 → `GetDraftStep1Result.NotDraft`
- `Step1Page` shows "This order is no longer a draft and cannot be edited." for the NotDraft case
- One new handler test: `HandleAsync_OrderIsNotInDraftStatus_ReturnsNotDraft`

## Files changed

- [GetDraftOrderHandler.cs](src/WidgetDepot.ApiService/Features/Orders/GetDraftOrder/GetDraftOrderHandler.cs) — added `NotDraft` error and status check
- [GetDraftOrderEndpoint.cs](src/WidgetDepot.ApiService/Features/Orders/GetDraftOrder/GetDraftOrderEndpoint.cs) — mapped `NotDraft` → 409
- [Step1Models.cs](src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Models.cs) — added `NotDraft` variant to `GetDraftStep1Result`
- [Step1Service.cs](src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Service.cs) — mapped 409 → `NotDraft`
- [Step1Page.razor](src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Page.razor) — distinct error message for `NotDraft`
- [GetDraftOrderHandlerTests.cs](tests/WidgetDepot.Tests/Features/Orders/GetDraftOrder/GetDraftOrderHandlerTests.cs) — new test

## Test plan
- [ ] All 26 GetDraftOrder + Step1 tests pass (`dotnet test --filter "GetDraftOrder|Step1"`)
- [ ] Navigating to `/orders/{submittedOrderId}/step1` shows "This order is no longer a draft and cannot be edited."

Closes story 12 gap (AC #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)