### PR TITLE
feat: add Save Draft button to Step 1

### DIFF
--- a/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Page.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Create/Step1/Step1Page.razor
@@ -108,16 +108,30 @@
             </table>
         }
 
+        @if (draftSavedMessage is not null)
+        {
+            <div class="alert alert-success alert-dismissible mt-2" role="alert">
+                @draftSavedMessage
+                <button type="button" class="btn-close" @onclick="() => draftSavedMessage = null" aria-label="Close"></button>
+            </div>
+        }
+
         @if (errorMessage is not null)
         {
             <div class="alert alert-danger mt-2">@errorMessage</div>
         }
 
         <div class="mt-3">
-            <button class="btn btn-primary" @onclick="HandleContinue"
-                    disabled="@(selectedItems.Count == 0 || isSubmitting)">
-                @(isSubmitting ? "Saving..." : "Continue")
-            </button>
+            <div class="d-flex gap-2">
+                <button class="btn btn-outline-secondary" @onclick="HandleSaveDraft"
+                        disabled="@(selectedItems.Count == 0 || isSubmitting || isSavingDraft)">
+                    @(isSavingDraft ? "Saving..." : "Save Draft")
+                </button>
+                <button class="btn btn-primary" @onclick="HandleContinue"
+                        disabled="@(selectedItems.Count == 0 || isSubmitting || isSavingDraft)">
+                    @(isSubmitting ? "Saving..." : "Continue")
+                </button>
+            </div>
             @if (selectedItems.Count == 0)
             {
                 <p class="text-muted small mt-1">Add at least one widget to continue.</p>
@@ -130,12 +144,18 @@
     [Parameter]
     public int OrderId { get; set; }
 
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "saved")]
+    public bool Saved { get; set; }
+
     private string? searchTerm;
     private IReadOnlyList<WidgetSearchResult> searchResults = [];
     private bool hasSearched;
     private readonly List<OrderItemModel> selectedItems = [];
     private string? errorMessage;
+    private string? draftSavedMessage;
     private bool isSubmitting;
+    private bool isSavingDraft;
 
     protected override async Task OnInitializedAsync()
     {
@@ -163,6 +183,11 @@
                 Weight = i.Weight,
                 Quantity = i.Quantity
             }));
+
+            if (Saved)
+            {
+                draftSavedMessage = "Draft saved.";
+            }
 
             return;
         }
@@ -219,6 +244,52 @@
     {
         if (int.TryParse(e.Value?.ToString(), out var qty) && qty >= 1)
             item.Quantity = qty;
+    }
+
+    private async Task HandleSaveDraft()
+    {
+        isSavingDraft = true;
+        errorMessage = null;
+        draftSavedMessage = null;
+
+        try
+        {
+            if (OrderId > 0)
+            {
+                var result = await Step1Service.UpdateDraftAsync(OrderId, selectedItems);
+
+                if (result is UpdateDraftResult.Success)
+                {
+                    draftSavedMessage = "Draft saved.";
+                }
+                else
+                {
+                    errorMessage = "An unexpected error occurred. Please try again.";
+                }
+            }
+            else
+            {
+                var result = await Step1Service.CreateDraftAsync(selectedItems);
+
+                switch (result)
+                {
+                    case CreateDraftResult.Success success:
+                        NavigationManager.NavigateTo($"/orders/{success.OrderId}/step1?saved=true");
+                        break;
+                    default:
+                        errorMessage = "An unexpected error occurred. Please try again.";
+                        break;
+                }
+            }
+        }
+        catch (Exception)
+        {
+            errorMessage = "An unexpected error occurred. Please try again.";
+        }
+        finally
+        {
+            isSavingDraft = false;
+        }
     }
 
     private async Task HandleContinue()

--- a/tests/WidgetDepot.Tests/Features/Orders/Create/Step1/Step1ServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/Create/Step1/Step1ServiceTests.cs
@@ -124,6 +124,48 @@ public class Step1ServiceTests
         result.ShouldBeOfType<GetDraftStep1Result.Failure>();
     }
 
+    [Fact]
+    public async Task UpdateDraftAsync_NoContentResponse_ReturnsSuccess()
+    {
+        var service = CreateService(HttpStatusCode.NoContent, "");
+        var items = new List<OrderItemModel>
+        {
+            new() { WidgetId = 1, Sku = "SPR-001", Name = "Sprocket", Weight = 1.5m, Quantity = 3 }
+        };
+
+        var result = await service.UpdateDraftAsync(5, items, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<UpdateDraftResult.Success>();
+    }
+
+    [Fact]
+    public async Task UpdateDraftAsync_ServerError_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError, "{}");
+        var items = new List<OrderItemModel>
+        {
+            new() { WidgetId = 1, Sku = "SPR-001", Name = "Sprocket", Weight = 1.5m, Quantity = 1 }
+        };
+
+        var result = await service.UpdateDraftAsync(5, items, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<UpdateDraftResult.Failure>();
+    }
+
+    [Fact]
+    public async Task UpdateDraftAsync_NotFound_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.NotFound, "{}");
+        var items = new List<OrderItemModel>
+        {
+            new() { WidgetId = 1, Sku = "SPR-001", Name = "Sprocket", Weight = 1.5m, Quantity = 1 }
+        };
+
+        var result = await service.UpdateDraftAsync(5, items, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<UpdateDraftResult.Failure>();
+    }
+
     private class FakeHttpMessageHandler(HttpStatusCode statusCode, string body) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

- Adds a secondary **Save Draft** button alongside **Continue** on Step 1 in both the new-order (`/orders/new`) and edit-draft (`/orders/{id}/step1`) flows
- New-order save path: calls `CreateDraftAsync`, navigates to `/orders/{id}/step1?saved=true`, which triggers a dismissible "Draft saved." success toast on arrival
- Edit-draft save path: calls `UpdateDraftAsync`, stays on page, shows the same inline toast
- Both buttons are disabled when no widgets are selected
- Adds 3 unit tests for `UpdateDraftAsync` (success, server error, not found)

## Test plan

- [x] Visit `/orders/new`, add a widget, click **Save Draft** — should redirect to `/orders/{id}/step1` showing "Draft saved." toast with widgets pre-loaded
- [x] On `/orders/{id}/step1`, change quantities, click **Save Draft** — toast appears inline, page stays put
- [x] Click **Save Draft** with no widgets selected — button is disabled
- [x] Click **Continue** — still navigates to address step as before

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)