### PR TITLE
Order transmission status on My Recent Orders

### DIFF
--- a/src/WidgetDepot.ApiService/Data/Migrations/20260528081103_AddOrderTransmissionStatus.Designer.cs
+++ b/src/WidgetDepot.ApiService/Data/Migrations/20260528081103_AddOrderTransmissionStatus.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WidgetDepot.ApiService.Data;
@@ -11,9 +12,11 @@ using WidgetDepot.ApiService.Data;
 namespace WidgetDepot.ApiService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260528081103_AddOrderTransmissionStatus")]
+    partial class AddOrderTransmissionStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WidgetDepot.ApiService/Data/Migrations/20260528081103_AddOrderTransmissionStatus.cs
+++ b/src/WidgetDepot.ApiService/Data/Migrations/20260528081103_AddOrderTransmissionStatus.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WidgetDepot.ApiService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrderTransmissionStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TransmissionStatus",
+                table: "Orders",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "TransmissionStatusChangedAt",
+                table: "Orders",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TransmissionStatus",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "TransmissionStatusChangedAt",
+                table: "Orders");
+        }
+    }
+}

--- a/src/WidgetDepot.ApiService/Data/Order.cs
+++ b/src/WidgetDepot.ApiService/Data/Order.cs
@@ -7,6 +7,14 @@ public enum OrderStatus
     Cancelled = 2
 }
 
+public enum TransmissionStatus
+{
+    Pending = 0,
+    Transmitted = 1,
+    Failed = 2,
+    Missing = 3
+}
+
 public class Order
 {
     public int Id { get; set; }
@@ -18,4 +26,6 @@ public class Order
     public Address? BillingAddress { get; set; }
     public decimal? ShippingEstimate { get; set; }
     public DateTime? SubmittedAt { get; set; }
+    public TransmissionStatus? TransmissionStatus { get; set; }
+    public DateTime? TransmissionStatusChangedAt { get; set; }
 }

--- a/src/WidgetDepot.ApiService/Features/Orders/GetRecentSubmitted/GetRecentSubmittedHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/GetRecentSubmitted/GetRecentSubmittedHandler.cs
@@ -4,7 +4,13 @@ using WidgetDepot.ApiService.Data;
 
 namespace WidgetDepot.ApiService.Features.Orders.GetRecentSubmitted;
 
-public record GetRecentSubmittedOrderResponse(int Id, DateTime SubmittedAt, int WidgetCount, decimal? ShippingEstimate);
+public record GetRecentSubmittedOrderResponse(
+    int Id,
+    DateTime SubmittedAt,
+    int WidgetCount,
+    decimal? ShippingEstimate,
+    TransmissionStatus TransmissionStatus,
+    DateTime? TransmissionStatusChangedAt);
 
 public class GetRecentSubmittedHandler(AppDbContext db)
 {
@@ -18,7 +24,9 @@ public class GetRecentSubmittedHandler(AppDbContext db)
                 o.Id,
                 o.SubmittedAt ?? DateTime.MinValue,
                 o.Items.Sum(i => i.Quantity),
-                o.ShippingEstimate))
+                o.ShippingEstimate,
+                o.TransmissionStatus ?? Data.TransmissionStatus.Pending,
+                o.TransmissionStatusChangedAt))
             .ToListAsync(cancellationToken);
     }
 }

--- a/src/WidgetDepot.ApiService/Features/Orders/Submit/SubmitOrderHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/Submit/SubmitOrderHandler.cs
@@ -59,6 +59,7 @@ public class SubmitOrderHandler
 
         order.Status = OrderStatus.Submitted;
         order.SubmittedAt = DateTime.UtcNow;
+        order.TransmissionStatus = TransmissionStatus.Pending;
 
         var orderFile = new OrderFile(order, customer.Email);
         await _orderFileWriter.WriteAsync(orderFile, cancellationToken);

--- a/src/WidgetDepot.Web/Features/Orders/History/HistoryModels.cs
+++ b/src/WidgetDepot.Web/Features/Orders/History/HistoryModels.cs
@@ -1,6 +1,20 @@
 namespace WidgetDepot.Web.Features.Orders.History;
 
-public record RecentOrderListItem(int Id, DateTime SubmittedAt, int WidgetCount, decimal? ShippingEstimate);
+public enum TransmissionStatus
+{
+    Pending = 0,
+    Transmitted = 1,
+    Failed = 2,
+    Missing = 3
+}
+
+public record RecentOrderListItem(
+    int Id,
+    DateTime SubmittedAt,
+    int WidgetCount,
+    decimal? ShippingEstimate,
+    TransmissionStatus TransmissionStatus,
+    DateTime? TransmissionStatusChangedAt);
 
 public abstract record GetRecentOrdersResult
 {
@@ -8,4 +22,10 @@ public abstract record GetRecentOrdersResult
     public record Failure : GetRecentOrdersResult;
 }
 
-internal record GetRecentSubmittedResponse(int Id, DateTime SubmittedAt, int WidgetCount, decimal? ShippingEstimate);
+internal record GetRecentSubmittedResponse(
+    int Id,
+    DateTime SubmittedAt,
+    int WidgetCount,
+    decimal? ShippingEstimate,
+    TransmissionStatus TransmissionStatus,
+    DateTime? TransmissionStatusChangedAt);

--- a/src/WidgetDepot.Web/Features/Orders/History/HistoryPage.razor
+++ b/src/WidgetDepot.Web/Features/Orders/History/HistoryPage.razor
@@ -30,6 +30,7 @@ else
                 <th>Submitted</th>
                 <th>Widgets</th>
                 <th>Est. Shipping</th>
+                <th>Transmission</th>
                 <th></th>
             </tr>
         </thead>
@@ -41,6 +42,13 @@ else
                     <td>@order.SubmittedAt.ToString("d")</td>
                     <td>@order.WidgetCount</td>
                     <td>@(order.ShippingEstimate.HasValue ? order.ShippingEstimate.Value.ToString("C") : "—")</td>
+                    <td>
+                        <span>@order.TransmissionStatus</span>
+                        @if (order.TransmissionStatus != TransmissionStatus.Pending && order.TransmissionStatusChangedAt.HasValue)
+                        {
+                            <span class="text-muted ms-1">@order.TransmissionStatusChangedAt.Value.ToString("g")</span>
+                        }
+                    </td>
                     <td>
                         <button class="btn btn-sm btn-primary" @onclick="() => NavigateToDetail(order.Id)">
                             View

--- a/src/WidgetDepot.Web/Features/Orders/History/HistoryService.cs
+++ b/src/WidgetDepot.Web/Features/Orders/History/HistoryService.cs
@@ -23,7 +23,13 @@ public class HistoryService
                 return new GetRecentOrdersResult.Failure();
 
             var items = orders
-                .Select(o => new RecentOrderListItem(o.Id, o.SubmittedAt, o.WidgetCount, o.ShippingEstimate))
+                .Select(o => new RecentOrderListItem(
+                    o.Id,
+                    o.SubmittedAt,
+                    o.WidgetCount,
+                    o.ShippingEstimate,
+                    o.TransmissionStatus,
+                    o.TransmissionStatusChangedAt))
                 .ToList();
 
             return new GetRecentOrdersResult.Success(items);

--- a/tests/WidgetDepot.Tests/Features/Orders/GetRecentSubmitted/GetRecentSubmittedHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/GetRecentSubmitted/GetRecentSubmittedHandlerTests.cs
@@ -17,14 +17,22 @@ public class GetRecentSubmittedHandlerTests
         return new AppDbContext(options);
     }
 
-    private static async Task<Order> SeedOrderAsync(AppDbContext db, int customerId, OrderStatus status, DateTime? submittedAt = null)
+    private static async Task<Order> SeedOrderAsync(
+        AppDbContext db,
+        int customerId,
+        OrderStatus status,
+        DateTime? submittedAt = null,
+        TransmissionStatus? transmissionStatus = null,
+        DateTime? transmissionStatusChangedAt = null)
     {
         var order = new Order
         {
             CustomerId = customerId,
             Status = status,
             CreatedAt = DateTime.UtcNow,
-            SubmittedAt = submittedAt
+            SubmittedAt = submittedAt,
+            TransmissionStatus = transmissionStatus,
+            TransmissionStatusChangedAt = transmissionStatusChangedAt
         };
         db.Orders.Add(order);
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
@@ -130,5 +138,60 @@ public class GetRecentSubmittedHandlerTests
         var result = await handler.HandleAsync(1, TestContext.Current.CancellationToken);
 
         result[0].ShippingEstimate.ShouldBe(19.99m);
+    }
+
+    [Fact]
+    public async Task HandleAsync_PendingTransmission_ReturnsPendingStatus()
+    {
+        using var db = CreateDb();
+        await SeedOrderAsync(db, customerId: 1, OrderStatus.Submitted, DateTime.UtcNow, TransmissionStatus.Pending);
+        var handler = new GetRecentSubmittedHandler(db);
+
+        var result = await handler.HandleAsync(1, TestContext.Current.CancellationToken);
+
+        result[0].TransmissionStatus.ShouldBe(TransmissionStatus.Pending);
+        result[0].TransmissionStatusChangedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmittedOrder_ReturnsStatusAndTimestamp()
+    {
+        using var db = CreateDb();
+        var changedAt = new DateTime(2026, 5, 15, 10, 0, 0, DateTimeKind.Utc);
+        await SeedOrderAsync(db, customerId: 1, OrderStatus.Submitted, DateTime.UtcNow, TransmissionStatus.Transmitted, changedAt);
+        var handler = new GetRecentSubmittedHandler(db);
+
+        var result = await handler.HandleAsync(1, TestContext.Current.CancellationToken);
+
+        result[0].TransmissionStatus.ShouldBe(TransmissionStatus.Transmitted);
+        result[0].TransmissionStatusChangedAt.ShouldBe(changedAt);
+    }
+
+    [Fact]
+    public async Task HandleAsync_FailedTransmission_ReturnsStatusAndTimestamp()
+    {
+        using var db = CreateDb();
+        var changedAt = new DateTime(2026, 5, 15, 10, 0, 0, DateTimeKind.Utc);
+        await SeedOrderAsync(db, customerId: 1, OrderStatus.Submitted, DateTime.UtcNow, TransmissionStatus.Failed, changedAt);
+        var handler = new GetRecentSubmittedHandler(db);
+
+        var result = await handler.HandleAsync(1, TestContext.Current.CancellationToken);
+
+        result[0].TransmissionStatus.ShouldBe(TransmissionStatus.Failed);
+        result[0].TransmissionStatusChangedAt.ShouldBe(changedAt);
+    }
+
+    [Fact]
+    public async Task HandleAsync_MissingTransmission_ReturnsStatusAndTimestamp()
+    {
+        using var db = CreateDb();
+        var changedAt = new DateTime(2026, 5, 15, 10, 0, 0, DateTimeKind.Utc);
+        await SeedOrderAsync(db, customerId: 1, OrderStatus.Submitted, DateTime.UtcNow, TransmissionStatus.Missing, changedAt);
+        var handler = new GetRecentSubmittedHandler(db);
+
+        var result = await handler.HandleAsync(1, TestContext.Current.CancellationToken);
+
+        result[0].TransmissionStatus.ShouldBe(TransmissionStatus.Missing);
+        result[0].TransmissionStatusChangedAt.ShouldBe(changedAt);
     }
 }

--- a/tests/WidgetDepot.Tests/Features/Orders/History/HistoryServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/History/HistoryServiceTests.cs
@@ -18,7 +18,7 @@ public class HistoryServiceTests
     [Fact]
     public async Task GetRecentOrdersAsync_SuccessResponse_ReturnsOrders()
     {
-        var body = """[{"id":1,"submittedAt":"2026-05-01T00:00:00","widgetCount":3,"shippingEstimate":12.50}]""";
+        var body = """[{"id":1,"submittedAt":"2026-05-01T00:00:00","widgetCount":3,"shippingEstimate":12.50,"transmissionStatus":0,"transmissionStatusChangedAt":null}]""";
         var service = CreateService(HttpStatusCode.OK, body);
 
         var result = await service.GetRecentOrdersAsync(TestContext.Current.CancellationToken);
@@ -28,6 +28,56 @@ public class HistoryServiceTests
         success.Orders[0].Id.ShouldBe(1);
         success.Orders[0].WidgetCount.ShouldBe(3);
         success.Orders[0].ShippingEstimate.ShouldBe(12.50m);
+    }
+
+    [Fact]
+    public async Task GetRecentOrdersAsync_PendingTransmission_ReturnsPendingStatus()
+    {
+        var body = """[{"id":1,"submittedAt":"2026-05-01T00:00:00","widgetCount":1,"shippingEstimate":null,"transmissionStatus":0,"transmissionStatusChangedAt":null}]""";
+        var service = CreateService(HttpStatusCode.OK, body);
+
+        var result = await service.GetRecentOrdersAsync(TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetRecentOrdersResult.Success>();
+        success.Orders[0].TransmissionStatus.ShouldBe(TransmissionStatus.Pending);
+        success.Orders[0].TransmissionStatusChangedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetRecentOrdersAsync_TransmittedOrder_ReturnsStatusAndTimestamp()
+    {
+        var body = """[{"id":1,"submittedAt":"2026-05-01T00:00:00","widgetCount":1,"shippingEstimate":null,"transmissionStatus":1,"transmissionStatusChangedAt":"2026-05-02T08:30:00"}]""";
+        var service = CreateService(HttpStatusCode.OK, body);
+
+        var result = await service.GetRecentOrdersAsync(TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetRecentOrdersResult.Success>();
+        success.Orders[0].TransmissionStatus.ShouldBe(TransmissionStatus.Transmitted);
+        success.Orders[0].TransmissionStatusChangedAt.ShouldBe(new DateTime(2026, 5, 2, 8, 30, 0));
+    }
+
+    [Fact]
+    public async Task GetRecentOrdersAsync_FailedOrder_ReturnsFailedStatus()
+    {
+        var body = """[{"id":1,"submittedAt":"2026-05-01T00:00:00","widgetCount":1,"shippingEstimate":null,"transmissionStatus":2,"transmissionStatusChangedAt":"2026-05-02T08:30:00"}]""";
+        var service = CreateService(HttpStatusCode.OK, body);
+
+        var result = await service.GetRecentOrdersAsync(TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetRecentOrdersResult.Success>();
+        success.Orders[0].TransmissionStatus.ShouldBe(TransmissionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task GetRecentOrdersAsync_MissingOrder_ReturnsMissingStatus()
+    {
+        var body = """[{"id":1,"submittedAt":"2026-05-01T00:00:00","widgetCount":1,"shippingEstimate":null,"transmissionStatus":3,"transmissionStatusChangedAt":"2026-05-02T08:30:00"}]""";
+        var service = CreateService(HttpStatusCode.OK, body);
+
+        var result = await service.GetRecentOrdersAsync(TestContext.Current.CancellationToken);
+
+        var success = result.ShouldBeOfType<GetRecentOrdersResult.Success>();
+        success.Orders[0].TransmissionStatus.ShouldBe(TransmissionStatus.Missing);
     }
 
     [Fact]

--- a/tests/WidgetDepot.Tests/Features/Orders/Submit/SubmitOrderHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/Submit/SubmitOrderHandlerTests.cs
@@ -254,6 +254,32 @@ public class SubmitOrderHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_ValidOrder_SetsTransmissionStatusToPending()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedFullOrderAsync(db);
+        var handler = CreateHandler(db);
+
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatus.ShouldBe(TransmissionStatus.Pending);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidOrder_DoesNotSetTransmissionStatusChangedAt()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedFullOrderAsync(db);
+        var handler = CreateHandler(db);
+
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatusChangedAt.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task HandleAsync_ValidOrder_CallsOrderFileWriter()
     {
         using var db = CreateDb();


### PR DESCRIPTION
## Summary
- Adds `TransmissionStatus` (Pending/Transmitted/Failed/Missing) and `TransmissionStatusChangedAt` to `Order`, with an EF migration.
- Submitting an order now sets `TransmissionStatus = Pending` (no timestamp).
- `/orders/recent` returns the new fields; My Recent Orders displays the status, with timestamp shown for Transmitted/Failed/Missing only.

Closes #118

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test` — 247 passed
- [x] Manual: submit an order and verify "Pending" appears with no timestamp on My Recent Orders
- [x] Manual: directly update an order's `TransmissionStatus`/`TransmissionStatusChangedAt` to Transmitted/Failed/Missing and verify the status + timestamp render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)