### PR TITLE
Add daily FTP transmission job for submitted orders

### DIFF
--- a/docs/standards/github-workflow.md
+++ b/docs/standards/github-workflow.md
@@ -42,13 +42,17 @@ git fetch --prune
 
 - Always use the GitHub CLI (`gh`) to interact with GitHub — never GitHub Actions
 - When specifying `--repo`, always run `gh repo view --json nameWithOwner -q .nameWithOwner` as a separate command first to get the repo name, then pass it as a literal value to the next `gh` command — never use `$(...)` subshell substitution and never parse the repo name from `git remote get-url origin`
+- When starting work on an issue, post a comment on the issue when starting work: "Starting work on this issue"
 - When starting work on an issue, run `gh issue view <number>` to read the full details before doing anything
 - Create a branch named `issue-<number>-short-description` **before any Edit or Write tool call**
-- Post a comment on the issue when starting work: "Starting work on this issue"
 - Post progress comments on the issue as significant steps are completed
 - Check off acceptance criteria checkboxes in the issue as each one is completed using `gh issue edit`
 - When work is complete, push the commits to the remote repo and open a PR using `gh pr create` with "Closes #<number>" in the body
 - Never commit directly to main, and never edit files while checked out on `main`
+- Never combine `git commit` with other commands. Always run `git commit` as a separate command.
+- Never add a 'Co-authored-by' footer in commit messages. Instead use the following:
+
+AI-Assisted-By: <Model Name>
 
 ---
 

--- a/src/WidgetDepot.ApiService/Features/Orders/Submit/OrderFileWriter.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/Submit/OrderFileWriter.cs
@@ -13,6 +13,11 @@ public class OrderFileWriter : IOrderFileWriter
 
     public async Task WriteAsync(OrderFile orderFile, CancellationToken cancellationToken)
     {
+        if (!Directory.Exists(_pickupDirectory))
+        {
+            Directory.CreateDirectory(_pickupDirectory);
+        }
+
         var filePath = Path.Combine(_pickupDirectory, orderFile.FileName);
         await File.WriteAllTextAsync(filePath, orderFile.GetContent(), cancellationToken);
     }

--- a/src/WidgetDepot.ApiService/Features/Orders/TransmitOrders/FtpOrderTransmitter.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/TransmitOrders/FtpOrderTransmitter.cs
@@ -1,0 +1,46 @@
+using FluentFTP;
+
+namespace WidgetDepot.ApiService.Features.Orders.TransmitOrders;
+
+public class FtpOrderTransmitter : IOrderTransmitter
+{
+    private readonly string _host;
+    private readonly int _port;
+    private readonly string _username;
+    private readonly string _password;
+    private readonly string _remoteDirectory;
+    private readonly ILogger<FtpOrderTransmitter> _logger;
+
+    public FtpOrderTransmitter(IConfiguration configuration, ILogger<FtpOrderTransmitter> logger)
+    {
+        _host = configuration["FtpTransmission:Host"] ?? throw new InvalidOperationException("FtpTransmission:Host is required.");
+        _port = configuration.GetValue("FtpTransmission:Port", 21);
+        _username = configuration["FtpTransmission:Username"] ?? throw new InvalidOperationException("FtpTransmission:Username is required.");
+        _password = configuration["FtpTransmission:Password"] ?? throw new InvalidOperationException("FtpTransmission:Password is required.");
+        _remoteDirectory = configuration.GetValue("FtpTransmission:RemoteDirectory", "/")!;
+        _logger = logger;
+    }
+
+    public async Task<bool> TransmitAsync(string localFilePath, string fileName, CancellationToken cancellationToken)
+    {
+        using var client = new AsyncFtpClient(_host, _username, _password, _port);
+
+        // PASV required for containerized deployments and the local dev FTP container.
+        client.Config.DataConnectionType = FtpDataConnectionType.PASV;
+
+        await client.Connect(cancellationToken);
+
+        var remotePath = $"{_remoteDirectory.TrimEnd('/')}/{fileName}";
+
+        var status = await client.UploadFile(
+            localPath: localFilePath,
+            remotePath: remotePath,
+            existsMode: FtpRemoteExists.Overwrite,
+            createRemoteDir: true,
+            token: cancellationToken);
+
+        _logger.LogInformation("FTP upload {FileName} → {RemotePath}: {Status}", fileName, remotePath, status);
+
+        return status == FtpStatus.Success;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/TransmitOrders/IOrderTransmitter.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/TransmitOrders/IOrderTransmitter.cs
@@ -1,0 +1,6 @@
+namespace WidgetDepot.ApiService.Features.Orders.TransmitOrders;
+
+public interface IOrderTransmitter
+{
+    Task<bool> TransmitAsync(string localFilePath, string fileName, CancellationToken cancellationToken);
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/TransmitOrders/TransmitOrdersHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/TransmitOrders/TransmitOrdersHandler.cs
@@ -1,0 +1,70 @@
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Orders.TransmitOrders;
+
+public class TransmitOrdersHandler
+{
+    private readonly AppDbContext _db;
+    private readonly IOrderTransmitter _transmitter;
+    private readonly string _pickupDirectory;
+    private readonly ILogger<TransmitOrdersHandler> _logger;
+
+    public TransmitOrdersHandler(
+        AppDbContext db,
+        IOrderTransmitter transmitter,
+        IConfiguration configuration,
+        ILogger<TransmitOrdersHandler> logger)
+    {
+        _db = db;
+        _transmitter = transmitter;
+        _pickupDirectory = configuration["Orders:PickupDirectory"] ?? "/tmp/orders";
+        _logger = logger;
+    }
+
+    public async Task<int> HandleAsync(CancellationToken cancellationToken)
+    {
+        var orders = await _db.Orders
+            .Where(o => o.TransmissionStatus == TransmissionStatus.Pending ||
+                        o.TransmissionStatus == TransmissionStatus.Missing)
+            .ToListAsync(cancellationToken);
+
+        var processed = 0;
+
+        foreach (var order in orders)
+        {
+            var fileName = $"EXT-{order.Id.ToString().PadLeft(10, '0')}.TXT";
+            var localFilePath = Path.Combine(_pickupDirectory, fileName);
+
+            if (!File.Exists(localFilePath))
+            {
+                order.TransmissionStatus = TransmissionStatus.Missing;
+                order.TransmissionStatusChangedAt = DateTime.UtcNow;
+                _logger.LogWarning("Order {OrderId} file not found: {FilePath}", order.Id, localFilePath);
+                processed++;
+                continue;
+            }
+
+            bool success;
+            try
+            {
+                success = await _transmitter.TransmitAsync(localFilePath, fileName, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "FTP transmission failed for order {OrderId}", order.Id);
+                success = false;
+            }
+
+            order.TransmissionStatus = success
+                ? TransmissionStatus.Transmitted
+                : TransmissionStatus.Failed;
+            order.TransmissionStatusChangedAt = DateTime.UtcNow;
+            processed++;
+        }
+
+        await _db.SaveChangesAsync(cancellationToken);
+        return processed;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/TransmitOrders/TransmitOrdersJob.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/TransmitOrders/TransmitOrdersJob.cs
@@ -1,0 +1,65 @@
+namespace WidgetDepot.ApiService.Features.Orders.TransmitOrders;
+
+public class TransmitOrdersJob : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<TransmitOrdersJob> _logger;
+    private readonly int _scheduleHourUtc;
+    private bool _first = true;
+
+    public TransmitOrdersJob(
+        IServiceScopeFactory scopeFactory,
+        ILogger<TransmitOrdersJob> logger,
+        IConfiguration configuration)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _scheduleHourUtc = configuration.GetValue("TransmissionJob:ScheduleHourUtc", 17);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var delay = TimeUntilNextScheduledRun();
+
+            try
+            {
+                _logger.LogInformation("TransmitOrdersJob: Delaying for {Delay}", delay);
+                await Task.Delay(delay, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+
+            await RunJobAsync(stoppingToken);
+        }
+    }
+
+    private async Task RunJobAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var handler = scope.ServiceProvider.GetRequiredService<TransmitOrdersHandler>();
+
+        var processed = await handler.HandleAsync(cancellationToken);
+        _logger.LogInformation("TransmitOrdersJob: processed {Count} order(s).", processed);
+    }
+
+    private TimeSpan TimeUntilNextScheduledRun()
+    {
+        if (_first)
+        {
+            _first = false;
+            return TimeSpan.Zero;
+        }
+
+        var now = DateTime.UtcNow;
+        var nextRun = now.Date.AddHours(_scheduleHourUtc);
+
+        if (nextRun <= now)
+            nextRun = nextRun.AddDays(1);
+
+        return nextRun - now;
+    }
+}

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -16,6 +16,7 @@ using WidgetDepot.ApiService.Features.Orders.GetDrafts;
 using WidgetDepot.ApiService.Features.Orders.GetRecentSubmitted;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
 using WidgetDepot.ApiService.Features.Orders.Submit;
+using WidgetDepot.ApiService.Features.Orders.TransmitOrders;
 using WidgetDepot.ApiService.Features.Orders.UpdateDraftItems;
 using WidgetDepot.ApiService.Features.Widgets.Import;
 using WidgetDepot.ApiService.Features.Widgets.Search;
@@ -73,7 +74,10 @@ builder.Services.AddScoped<GetRecentSubmittedHandler>();
 builder.Services.AddScoped<IOrderFileWriter, OrderFileWriter>();
 builder.Services.AddScoped<ExpireDraftOrdersHandler>();
 builder.Services.AddScoped<GetByOrderNumberHandler>();
+builder.Services.AddScoped<IOrderTransmitter, FtpOrderTransmitter>();
+builder.Services.AddScoped<TransmitOrdersHandler>();
 builder.Services.AddHostedService<ExpireDraftOrdersJob>();
+builder.Services.AddHostedService<TransmitOrdersJob>();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();

--- a/src/WidgetDepot.ApiService/WidgetDepot.ApiService.csproj
+++ b/src/WidgetDepot.ApiService/WidgetDepot.ApiService.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.2.4" />
+    <PackageReference Include="FluentFTP" Version="54.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WidgetDepot.ApiService/appsettings.json
+++ b/src/WidgetDepot.ApiService/appsettings.json
@@ -11,5 +11,12 @@
   },
   "TransmissionJob": {
     "ScheduleHourUtc": 17
+  },
+  "FtpTransmission": {
+    "Host": "",
+    "Port": 21,
+    "Username": "",
+    "Password": "",
+    "RemoteDirectory": ""
   }
 }

--- a/src/WidgetDepot.ApiService/appsettings.json
+++ b/src/WidgetDepot.ApiService/appsettings.json
@@ -8,5 +8,8 @@
   "AllowedHosts": "*",
   "Orders": {
     "PickupDirectory": "/tmp/orders"
+  },
+  "TransmissionJob": {
+    "ScheduleHourUtc": 17
   }
 }

--- a/src/WidgetDepot.AppHost/AppHost.cs
+++ b/src/WidgetDepot.AppHost/AppHost.cs
@@ -2,6 +2,33 @@ using System.Net.Sockets;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+const int ftpHostPort = 2121;
+const int passivePortStart = 21000;
+const int passivePortEnd = 21010;
+
+var ftp = builder
+    .AddContainer("fake-ftp", "delfer/alpine-ftp-server")
+    .WithEnvironment("USERS", "devftp|devftp|/home/devftp")
+    .WithEnvironment("ADDRESS", "127.0.0.1")
+    .WithEnvironment("MIN_PORT", passivePortStart.ToString())
+    .WithEnvironment("MAX_PORT", passivePortEnd.ToString())
+    .WithEndpoint(
+        port: ftpHostPort,
+        targetPort: 21,
+        scheme: "ftp",
+        name: "ftp",
+        isProxied: false);
+
+for (var port = passivePortStart; port <= passivePortEnd; port++)
+{
+    ftp = ftp.WithEndpoint(
+        port: port,
+        targetPort: port,
+        scheme: "tcp",
+        name: $"ftp-passive-{port}",
+        isProxied: false);
+}
+
 var postgres = builder.AddPostgres("postgres")
     .WithLifetime(ContainerLifetime.Persistent)
     .WithContainerName("postgres")
@@ -23,7 +50,12 @@ var apiService = builder.AddProject<Projects.WidgetDepot_ApiService>("apiservice
     .WithReference(postgres)
     .WaitFor(postgres)
     .WithReference(fakeShippingApi)
-    .WaitFor(fakeShippingApi);
+    .WaitFor(fakeShippingApi)
+    .WithEnvironment("FtpTransmission__Host", "127.0.0.1")
+    .WithEnvironment("FtpTransmission__Port", ftpHostPort.ToString())
+    .WithEnvironment("FtpTransmission__Username", "devftp")
+    .WithEnvironment("FtpTransmission__Password", "devftp")
+    .WithEnvironment("FtpTransmission__RemoteDirectory", "/home/devftp");
 
 builder.AddProject<Projects.WidgetDepot_Web>("webfrontend")
     .WithExternalHttpEndpoints()

--- a/src/WidgetDepot.AppHost/AppHost.cs
+++ b/src/WidgetDepot.AppHost/AppHost.cs
@@ -1,33 +1,9 @@
 using System.Net.Sockets;
+using WidgetDepot.AppHost;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-const int ftpHostPort = 2121;
-const int passivePortStart = 21000;
-const int passivePortEnd = 21010;
-
-var ftp = builder
-    .AddContainer("fake-ftp", "delfer/alpine-ftp-server")
-    .WithEnvironment("USERS", "devftp|devftp|/home/devftp")
-    .WithEnvironment("ADDRESS", "127.0.0.1")
-    .WithEnvironment("MIN_PORT", passivePortStart.ToString())
-    .WithEnvironment("MAX_PORT", passivePortEnd.ToString())
-    .WithEndpoint(
-        port: ftpHostPort,
-        targetPort: 21,
-        scheme: "ftp",
-        name: "ftp",
-        isProxied: false);
-
-for (var port = passivePortStart; port <= passivePortEnd; port++)
-{
-    ftp = ftp.WithEndpoint(
-        port: port,
-        targetPort: port,
-        scheme: "tcp",
-        name: $"ftp-passive-{port}",
-        isProxied: false);
-}
+var ftp = builder.AddFakeFtp();
 
 var postgres = builder.AddPostgres("postgres")
     .WithLifetime(ContainerLifetime.Persistent)
@@ -51,8 +27,9 @@ var apiService = builder.AddProject<Projects.WidgetDepot_ApiService>("apiservice
     .WaitFor(postgres)
     .WithReference(fakeShippingApi)
     .WaitFor(fakeShippingApi)
+    .WaitFor(ftp)
     .WithEnvironment("FtpTransmission__Host", "127.0.0.1")
-    .WithEnvironment("FtpTransmission__Port", ftpHostPort.ToString())
+    .WithEnvironment("FtpTransmission__Port", FtpContainerExtensions.FtpHostPort.ToString())
     .WithEnvironment("FtpTransmission__Username", "devftp")
     .WithEnvironment("FtpTransmission__Password", "devftp")
     .WithEnvironment("FtpTransmission__RemoteDirectory", "/home/devftp");

--- a/src/WidgetDepot.AppHost/FtpContainerExtensions.cs
+++ b/src/WidgetDepot.AppHost/FtpContainerExtensions.cs
@@ -1,0 +1,37 @@
+namespace WidgetDepot.AppHost;
+
+public static class FtpContainerExtensions
+{
+    public const int FtpHostPort = 2121;
+
+    public static IResourceBuilder<ContainerResource> AddFakeFtp(this IDistributedApplicationBuilder builder)
+    {
+        const int passivePortStart = 21000;
+        const int passivePortEnd = 21010;
+
+        var ftp = builder
+            .AddContainer("fake-ftp", "delfer/alpine-ftp-server")
+            .WithEnvironment("USERS", "devftp|devftp|/home/devftp")
+            .WithEnvironment("ADDRESS", "127.0.0.1")
+            .WithEnvironment("MIN_PORT", passivePortStart.ToString())
+            .WithEnvironment("MAX_PORT", passivePortEnd.ToString())
+            .WithEndpoint(
+                port: FtpHostPort,
+                targetPort: 21,
+                scheme: "ftp",
+                name: "ftp",
+                isProxied: false);
+
+        for (var port = passivePortStart; port <= passivePortEnd; port++)
+        {
+            ftp = ftp.WithEndpoint(
+                port: port,
+                targetPort: port,
+                scheme: "tcp",
+                name: $"ftp-passive-{port}",
+                isProxied: false);
+        }
+
+        return ftp;
+    }
+}

--- a/src/WidgetDepot.AppHost/FtpContainerExtensions.cs
+++ b/src/WidgetDepot.AppHost/FtpContainerExtensions.cs
@@ -11,6 +11,8 @@ public static class FtpContainerExtensions
 
         var ftp = builder
             .AddContainer("fake-ftp", "delfer/alpine-ftp-server")
+            .WithLifetime(ContainerLifetime.Persistent)
+            .WithContainerName("fake-ftp")
             .WithEnvironment("USERS", "devftp|devftp|/home/devftp")
             .WithEnvironment("ADDRESS", "127.0.0.1")
             .WithEnvironment("MIN_PORT", passivePortStart.ToString())

--- a/tests/WidgetDepot.Tests/Features/Orders/TransmitOrders/TransmitOrdersHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/TransmitOrders/TransmitOrdersHandlerTests.cs
@@ -1,0 +1,258 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.TransmitOrders;
+
+namespace WidgetDepot.Tests.Features.Orders.TransmitOrders;
+
+public class TransmitOrdersHandlerTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public TransmitOrdersHandlerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private TransmitOrdersHandler CreateHandler(
+        AppDbContext db,
+        IOrderTransmitter? transmitter = null,
+        string? pickupDirectory = null)
+    {
+        var mockTransmitter = transmitter ?? new Mock<IOrderTransmitter>().Object;
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Orders:PickupDirectory"] = pickupDirectory ?? _tempDir
+            })
+            .Build();
+        var logger = new Mock<ILogger<TransmitOrdersHandler>>().Object;
+        return new TransmitOrdersHandler(db, mockTransmitter, config, logger);
+    }
+
+    private static async Task<Order> SeedOrderAsync(AppDbContext db, TransmissionStatus? transmissionStatus)
+    {
+        var order = new Order
+        {
+            CustomerId = 1,
+            Status = OrderStatus.Submitted,
+            CreatedAt = DateTime.UtcNow,
+            TransmissionStatus = transmissionStatus
+        };
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return order;
+    }
+
+    private string CreateOrderFile(int orderId)
+    {
+        var fileName = $"EXT-{orderId.ToString().PadLeft(10, '0')}.TXT";
+        var path = Path.Combine(_tempDir, fileName);
+        File.WriteAllText(path, "test content");
+        return path;
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoPendingOrders_ReturnsZero()
+    {
+        using var db = CreateDb();
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task HandleAsync_FileNotFound_SetsStatusToMissing()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, TransmissionStatus.Pending);
+        var handler = CreateHandler(db);
+
+        await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatus.ShouldBe(TransmissionStatus.Missing);
+    }
+
+    [Fact]
+    public async Task HandleAsync_FileNotFound_SetsTransmissionStatusChangedAt()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, TransmissionStatus.Pending);
+        var handler = CreateHandler(db);
+
+        var before = DateTime.UtcNow;
+        await handler.HandleAsync(TestContext.Current.CancellationToken);
+        var after = DateTime.UtcNow;
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatusChangedAt.ShouldNotBeNull();
+        saved.TransmissionStatusChangedAt.Value.ShouldBeGreaterThanOrEqualTo(before);
+        saved.TransmissionStatusChangedAt.Value.ShouldBeLessThanOrEqualTo(after);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionSucceeds_SetsStatusToTransmitted()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, TransmissionStatus.Pending);
+        CreateOrderFile(order.Id);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter
+            .Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandler(db, transmitter.Object);
+
+        await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatus.ShouldBe(TransmissionStatus.Transmitted);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionSucceeds_SetsTransmissionStatusChangedAt()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, TransmissionStatus.Pending);
+        CreateOrderFile(order.Id);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter
+            .Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandler(db, transmitter.Object);
+
+        var before = DateTime.UtcNow;
+        await handler.HandleAsync(TestContext.Current.CancellationToken);
+        var after = DateTime.UtcNow;
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatusChangedAt.ShouldNotBeNull();
+        saved.TransmissionStatusChangedAt.Value.ShouldBeGreaterThanOrEqualTo(before);
+        saved.TransmissionStatusChangedAt.Value.ShouldBeLessThanOrEqualTo(after);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionFails_SetsStatusToFailed()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, TransmissionStatus.Pending);
+        CreateOrderFile(order.Id);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter
+            .Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var handler = CreateHandler(db, transmitter.Object);
+
+        await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatus.ShouldBe(TransmissionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionThrows_SetsStatusToFailed()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, TransmissionStatus.Pending);
+        CreateOrderFile(order.Id);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter
+            .Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("FTP error"));
+
+        var handler = CreateHandler(db, transmitter.Object);
+
+        await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatus.ShouldBe(TransmissionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderWithFailedStatus_IsNotProcessed()
+    {
+        using var db = CreateDb();
+        await SeedOrderAsync(db, TransmissionStatus.Failed);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        var handler = CreateHandler(db, transmitter.Object);
+
+        var result = await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0);
+        transmitter.Verify(
+            t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderWithMissingStatus_IsRetried()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, TransmissionStatus.Missing);
+        CreateOrderFile(order.Id);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter
+            .Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandler(db, transmitter.Object);
+
+        await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatus.ShouldBe(TransmissionStatus.Transmitted);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionSucceeds_CallsTransmitterWithCorrectFileName()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, TransmissionStatus.Pending);
+        CreateOrderFile(order.Id);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter
+            .Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandler(db, transmitter.Object);
+
+        await handler.HandleAsync(TestContext.Current.CancellationToken);
+
+        var expectedFileName = $"EXT-{order.Id.ToString().PadLeft(10, '0')}.TXT";
+        transmitter.Verify(
+            t => t.TransmitAsync(It.IsAny<string>(), expectedFileName, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `TransmitOrdersJob`, a `BackgroundService` that runs at 5 PM UTC (configurable via `TransmissionJob:ScheduleHourUtc`) and transmits ERP order files for all `Pending` and `Missing` orders
- Adds `FtpOrderTransmitter` (using FluentFTP v54 `AsyncFtpClient`) behind an `IOrderTransmitter` interface for testability; FTP connection settings come from `FtpTransmission:*` config
- Adds a `delfer/alpine-ftp-server` container to the Aspire AppHost for local development, with passive port range 21000–21010 and credentials injected into the API service via environment variables
- Job runs immediately on startup, then on the daily schedule; processes `Pending` and `Missing` orders each run, skips `Failed` orders

## Test plan

- [x] 10 new unit tests cover: no-op when no pending orders, file-not-found → `Missing`, successful transmission → `Transmitted`, FTP return false → `Failed`, FTP exception → `Failed`, `Failed` orders are skipped, `Missing` orders are retried, timestamp is set, correct filename is passed
- [x] All 257 unit tests pass (`dotnet test` excluding integration WebTests)
- [x] Solution builds cleanly with 0 warnings

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)