### PR TITLE
On-Demand Retransmission for Failed Orders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,10 @@ Branch creation is a **precondition**, not a step. Before the first Edit or Writ
 
 **Never run Edit or Write tools while checked out on `main` or on a stale task branch.** If you notice mid-task that you are on the wrong branch, stop and switch before making further changes.
 
+**Never add a 'Co-authored-by' footer in commit messages**. Instead use the following:
+
+AI-Assisted-By: <Model Name>
+
 ---
 
 

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
@@ -5,6 +5,7 @@ using WidgetDepot.ApiService.Features.Orders.GetByOrderNumber;
 using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.GetDrafts;
 using WidgetDepot.ApiService.Features.Orders.GetRecentSubmitted;
+using WidgetDepot.ApiService.Features.Orders.RetransmitOrder;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
 using WidgetDepot.ApiService.Features.Orders.Submit;
 using WidgetDepot.ApiService.Features.Orders.UpdateDraftItems;
@@ -25,6 +26,7 @@ public static class OrderEndpointExtensions
         app.MapUpdateDraftItems();
         app.MapGetRecentSubmitted();
         app.MapGetByOrderNumber();
+        app.MapRetransmitOrder();
 
         return app;
     }

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
@@ -14,4 +14,5 @@ public static class OrderEndpoints
     public const string UpdateDraftItems = $"{Base}/{{orderId}}/items";
     public const string GetRecentSubmitted = $"{Base}/recent";
     public const string GetByOrderNumber = $"{Base}/{{orderNumber}}";
+    public const string RetransmitOrder = $"{Base}/{{orderId}}/retransmit";
 }

--- a/src/WidgetDepot.ApiService/Features/Orders/RetransmitOrder/RetransmitOrderEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/RetransmitOrder/RetransmitOrderEndpoint.cs
@@ -1,0 +1,33 @@
+using System.Security.Claims;
+
+namespace WidgetDepot.ApiService.Features.Orders.RetransmitOrder;
+
+public static class RetransmitOrderEndpoint
+{
+    public static IEndpointRouteBuilder MapRetransmitOrder(this IEndpointRouteBuilder app)
+    {
+        app.MapPost(OrderEndpoints.RetransmitOrder, async (
+            int orderId,
+            ClaimsPrincipal user,
+            RetransmitOrderHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            if (!user.TryGetCustomerId(out var customerId))
+                return Results.Unauthorized();
+
+            var result = await handler.HandleAsync(orderId, customerId, cancellationToken);
+
+            return result switch
+            {
+                RetransmitOrderNotFound => Results.NotFound(),
+                RetransmitOrderInvalidStatus => Results.Conflict(),
+                RetransmitOrderResponse response => Results.Ok(response),
+                _ => Results.Problem(statusCode: 500)
+            };
+        })
+        .WithName("RetransmitOrder")
+        .RequireAuthorization();
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/RetransmitOrder/RetransmitOrderHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/RetransmitOrder/RetransmitOrderHandler.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 
 using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.Submit;
 using WidgetDepot.ApiService.Features.Orders.TransmitOrders;
 
 namespace WidgetDepot.ApiService.Features.Orders.RetransmitOrder;
@@ -39,7 +40,7 @@ public class RetransmitOrderHandler
         if (order.TransmissionStatus != TransmissionStatus.Failed)
             return new RetransmitOrderInvalidStatus();
 
-        var fileName = $"EXT-{order.Id.ToString().PadLeft(10, '0')}.TXT";
+        var fileName = OrderFile.GetFileName(order.Id);
         var localFilePath = Path.Combine(_pickupDirectory, fileName);
 
         if (!File.Exists(localFilePath))

--- a/src/WidgetDepot.ApiService/Features/Orders/RetransmitOrder/RetransmitOrderHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/RetransmitOrder/RetransmitOrderHandler.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.TransmitOrders;
+
+namespace WidgetDepot.ApiService.Features.Orders.RetransmitOrder;
+
+public record RetransmitOrderResponse(TransmissionStatus NewStatus, DateTime StatusChangedAt);
+public record RetransmitOrderNotFound;
+public record RetransmitOrderInvalidStatus;
+
+public class RetransmitOrderHandler
+{
+    private readonly AppDbContext _db;
+    private readonly IOrderTransmitter _transmitter;
+    private readonly string _pickupDirectory;
+    private readonly ILogger<RetransmitOrderHandler> _logger;
+
+    public RetransmitOrderHandler(
+        AppDbContext db,
+        IOrderTransmitter transmitter,
+        IConfiguration configuration,
+        ILogger<RetransmitOrderHandler> logger)
+    {
+        _db = db;
+        _transmitter = transmitter;
+        _pickupDirectory = configuration["Orders:PickupDirectory"] ?? "/tmp/orders";
+        _logger = logger;
+    }
+
+    public async Task<object> HandleAsync(int orderId, int customerId, CancellationToken cancellationToken)
+    {
+        var order = await _db.Orders
+            .FirstOrDefaultAsync(o => o.Id == orderId && o.CustomerId == customerId, cancellationToken);
+
+        if (order is null)
+            return new RetransmitOrderNotFound();
+
+        if (order.TransmissionStatus != TransmissionStatus.Failed)
+            return new RetransmitOrderInvalidStatus();
+
+        var fileName = $"EXT-{order.Id.ToString().PadLeft(10, '0')}.TXT";
+        var localFilePath = Path.Combine(_pickupDirectory, fileName);
+
+        if (!File.Exists(localFilePath))
+        {
+            order.TransmissionStatus = TransmissionStatus.Missing;
+            order.TransmissionStatusChangedAt = DateTime.UtcNow;
+            _logger.LogWarning("Order {OrderId} file not found: {FilePath}", order.Id, localFilePath);
+            await _db.SaveChangesAsync(cancellationToken);
+            return new RetransmitOrderResponse(order.TransmissionStatus.Value, order.TransmissionStatusChangedAt!.Value);
+        }
+
+        bool success;
+        try
+        {
+            success = await _transmitter.TransmitAsync(localFilePath, fileName, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "FTP transmission failed for order {OrderId}", order.Id);
+            success = false;
+        }
+
+        order.TransmissionStatus = success ? TransmissionStatus.Transmitted : TransmissionStatus.Failed;
+        order.TransmissionStatusChangedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return new RetransmitOrderResponse(order.TransmissionStatus.Value, order.TransmissionStatusChangedAt.Value);
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/Submit/OrderFile.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/Submit/OrderFile.cs
@@ -11,9 +11,12 @@ public class OrderFile
 
     public string FileName { get; }
 
+    public static string GetFileName(int orderId) =>
+        $"EXT-{orderId.ToString().PadLeft(10, '0')}.TXT";
+
     public OrderFile(Order order, string customerEmail)
     {
-        FileName = $"EXT-{order.Id.ToString().PadLeft(10, '0')}.TXT";
+        FileName = GetFileName(order.Id);
         _order = order;
         _customerEmail = customerEmail;
     }

--- a/src/WidgetDepot.ApiService/Features/Orders/TransmitOrders/TransmitOrdersHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/TransmitOrders/TransmitOrdersHandler.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 
 using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.Submit;
 
 namespace WidgetDepot.ApiService.Features.Orders.TransmitOrders;
 
@@ -34,7 +35,7 @@ public class TransmitOrdersHandler
 
         foreach (var order in orders)
         {
-            var fileName = $"EXT-{order.Id.ToString().PadLeft(10, '0')}.TXT";
+            var fileName = OrderFile.GetFileName(order.Id);
             var localFilePath = Path.Combine(_pickupDirectory, fileName);
 
             if (!File.Exists(localFilePath))

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -14,6 +14,7 @@ using WidgetDepot.ApiService.Features.Orders.GetByOrderNumber;
 using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.GetDrafts;
 using WidgetDepot.ApiService.Features.Orders.GetRecentSubmitted;
+using WidgetDepot.ApiService.Features.Orders.RetransmitOrder;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
 using WidgetDepot.ApiService.Features.Orders.Submit;
 using WidgetDepot.ApiService.Features.Orders.TransmitOrders;
@@ -76,6 +77,7 @@ builder.Services.AddScoped<ExpireDraftOrdersHandler>();
 builder.Services.AddScoped<GetByOrderNumberHandler>();
 builder.Services.AddScoped<IOrderTransmitter, FtpOrderTransmitter>();
 builder.Services.AddScoped<TransmitOrdersHandler>();
+builder.Services.AddScoped<RetransmitOrderHandler>();
 builder.Services.AddHostedService<ExpireDraftOrdersJob>();
 builder.Services.AddHostedService<TransmitOrdersJob>();
 

--- a/src/WidgetDepot.Web/Features/Orders/History/HistoryModels.cs
+++ b/src/WidgetDepot.Web/Features/Orders/History/HistoryModels.cs
@@ -29,3 +29,13 @@ internal record GetRecentSubmittedResponse(
     decimal? ShippingEstimate,
     TransmissionStatus TransmissionStatus,
     DateTime? TransmissionStatusChangedAt);
+
+internal record RetransmitOrderApiResponse(TransmissionStatus NewStatus, DateTime StatusChangedAt);
+
+public abstract record RetransmitResult
+{
+    public record Transmitted : RetransmitResult;
+    public record Missing : RetransmitResult;
+    public record Failed : RetransmitResult;
+    public record Failure : RetransmitResult;
+}

--- a/src/WidgetDepot.Web/Features/Orders/History/HistoryPage.razor
+++ b/src/WidgetDepot.Web/Features/Orders/History/HistoryPage.razor
@@ -9,6 +9,14 @@
 
 <h1>My Recent Orders</h1>
 
+@if (retransmitMessage is not null)
+{
+    <div class="alert @retransmitMessageClass alert-dismissible" role="alert">
+        @retransmitMessage
+        <button type="button" class="btn-close" @onclick="DismissRetransmitMessage" aria-label="Close"></button>
+    </div>
+}
+
 @if (isLoading)
 {
     <p>Loading...</p>
@@ -53,6 +61,21 @@ else
                         <button class="btn btn-sm btn-primary" @onclick="() => NavigateToDetail(order.Id)">
                             View
                         </button>
+                        @if (order.TransmissionStatus == TransmissionStatus.Failed)
+                        {
+                            @if (confirmingOrderId == order.Id)
+                            {
+                                <span class="ms-2 me-1">Retransmit this order?</span>
+                                <button class="btn btn-sm btn-warning me-1" @onclick="() => ConfirmRetransmitAsync(order.Id)">Yes</button>
+                                <button class="btn btn-sm btn-secondary" @onclick="CancelRetransmit">No</button>
+                            }
+                            else
+                            {
+                                <button class="btn btn-sm btn-warning ms-1" @onclick="() => RequestRetransmit(order.Id)">
+                                    Retransmit
+                                </button>
+                            }
+                        }
                     </td>
                 </tr>
             }
@@ -67,6 +90,10 @@ else
     private IReadOnlyList<RecentOrderListItem> orders = [];
     private bool isLoading = true;
     private bool loadFailed;
+
+    private int? confirmingOrderId;
+    private string? retransmitMessage;
+    private string retransmitMessageClass = "alert-success";
 
     protected override async Task OnInitializedAsync()
     {
@@ -88,5 +115,58 @@ else
     private void NavigateToDetail(int orderId)
     {
         NavigationManager.NavigateTo($"/orders/{orderId}");
+    }
+
+    private void RequestRetransmit(int orderId)
+    {
+        confirmingOrderId = orderId;
+        retransmitMessage = null;
+    }
+
+    private void CancelRetransmit()
+    {
+        confirmingOrderId = null;
+    }
+
+    private void DismissRetransmitMessage()
+    {
+        retransmitMessage = null;
+    }
+
+    private async Task ConfirmRetransmitAsync(int orderId)
+    {
+        confirmingOrderId = null;
+
+        var result = await HistoryService.RetransmitOrderAsync(orderId);
+
+        switch (result)
+        {
+            case RetransmitResult.Transmitted:
+                retransmitMessageClass = "alert-success";
+                retransmitMessage = "Order file successfully transmitted.";
+                await RefreshOrdersAsync();
+                break;
+            case RetransmitResult.Missing:
+                retransmitMessageClass = "alert-warning";
+                retransmitMessage = "Order file was not found. The order status has been updated to Missing and will be retried in the next daily batch.";
+                await RefreshOrdersAsync();
+                break;
+            case RetransmitResult.Failed:
+                retransmitMessageClass = "alert-danger";
+                retransmitMessage = "Retransmission failed. Please try again later.";
+                await RefreshOrdersAsync();
+                break;
+            default:
+                retransmitMessageClass = "alert-danger";
+                retransmitMessage = "An error occurred. Please try again later.";
+                break;
+        }
+    }
+
+    private async Task RefreshOrdersAsync()
+    {
+        var result = await HistoryService.GetRecentOrdersAsync();
+        if (result is GetRecentOrdersResult.Success success)
+            orders = success.Orders;
     }
 }

--- a/src/WidgetDepot.Web/Features/Orders/History/HistoryService.cs
+++ b/src/WidgetDepot.Web/Features/Orders/History/HistoryService.cs
@@ -12,6 +12,28 @@ public class HistoryService
         _httpClient = httpClient;
     }
 
+    public async Task<RetransmitResult> RetransmitOrderAsync(int orderId, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.PostAsync($"/orders/{orderId}/retransmit", null, cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var result = await response.Content.ReadFromJsonAsync<RetransmitOrderApiResponse>(cancellationToken);
+            if (result is null)
+                return new RetransmitResult.Failure();
+
+            return result.NewStatus switch
+            {
+                TransmissionStatus.Transmitted => new RetransmitResult.Transmitted(),
+                TransmissionStatus.Missing => new RetransmitResult.Missing(),
+                TransmissionStatus.Failed => new RetransmitResult.Failed(),
+                _ => new RetransmitResult.Failure()
+            };
+        }
+
+        return new RetransmitResult.Failure();
+    }
+
     public async Task<GetRecentOrdersResult> GetRecentOrdersAsync(CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.GetAsync("/orders/recent", cancellationToken);

--- a/tests/WidgetDepot.Tests/Features/Orders/RetransmitOrder/RetransmitOrderHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/RetransmitOrder/RetransmitOrderHandlerTests.cs
@@ -1,0 +1,313 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.RetransmitOrder;
+using WidgetDepot.ApiService.Features.Orders.TransmitOrders;
+
+namespace WidgetDepot.Tests.Features.Orders.RetransmitOrder;
+
+public class RetransmitOrderHandlerTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public RetransmitOrderHandlerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private RetransmitOrderHandler CreateHandler(
+        AppDbContext db,
+        IOrderTransmitter? transmitter = null,
+        string? pickupDirectory = null)
+    {
+        var mockTransmitter = transmitter ?? new Mock<IOrderTransmitter>().Object;
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Orders:PickupDirectory"] = pickupDirectory ?? _tempDir
+            })
+            .Build();
+        var logger = new Mock<ILogger<RetransmitOrderHandler>>().Object;
+        return new RetransmitOrderHandler(db, mockTransmitter, config, logger);
+    }
+
+    private static async Task<Order> SeedOrderAsync(AppDbContext db, int customerId, TransmissionStatus? transmissionStatus)
+    {
+        var order = new Order
+        {
+            CustomerId = customerId,
+            Status = OrderStatus.Submitted,
+            CreatedAt = DateTime.UtcNow,
+            TransmissionStatus = transmissionStatus
+        };
+        db.Orders.Add(order);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return order;
+    }
+
+    private string CreateOrderFile(int orderId)
+    {
+        var fileName = $"EXT-{orderId.ToString().PadLeft(10, '0')}.TXT";
+        var path = Path.Combine(_tempDir, fileName);
+        File.WriteAllText(path, "test content");
+        return path;
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderNotFound_ReturnsNotFound()
+    {
+        using var db = CreateDb();
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(999, 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RetransmitOrderNotFound>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderBelongsToDifferentCustomer_ReturnsNotFound()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, TransmissionStatus.Failed);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 2, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RetransmitOrderNotFound>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderStatusIsPending_ReturnsInvalidStatus()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, TransmissionStatus.Pending);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RetransmitOrderInvalidStatus>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderStatusIsTransmitted_ReturnsInvalidStatus()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, TransmissionStatus.Transmitted);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RetransmitOrderInvalidStatus>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderStatusIsMissing_ReturnsInvalidStatus()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, TransmissionStatus.Missing);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RetransmitOrderInvalidStatus>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_FileNotFound_SetsStatusToMissing()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, TransmissionStatus.Failed);
+        var handler = CreateHandler(db);
+
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatus.ShouldBe(TransmissionStatus.Missing);
+    }
+
+    [Fact]
+    public async Task HandleAsync_FileNotFound_ReturnsResponseWithMissingStatus()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, TransmissionStatus.Failed);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<RetransmitOrderResponse>();
+        response.NewStatus.ShouldBe(TransmissionStatus.Missing);
+    }
+
+    [Fact]
+    public async Task HandleAsync_FileNotFound_SetsTransmissionStatusChangedAt()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, TransmissionStatus.Failed);
+        var handler = CreateHandler(db);
+
+        var before = DateTime.UtcNow;
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+        var after = DateTime.UtcNow;
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatusChangedAt.ShouldNotBeNull();
+        saved.TransmissionStatusChangedAt.Value.ShouldBeGreaterThanOrEqualTo(before);
+        saved.TransmissionStatusChangedAt.Value.ShouldBeLessThanOrEqualTo(after);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionSucceeds_SetsStatusToTransmitted()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, TransmissionStatus.Failed);
+        CreateOrderFile(order.Id);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter
+            .Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandler(db, transmitter.Object);
+
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatus.ShouldBe(TransmissionStatus.Transmitted);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionSucceeds_ReturnsResponseWithTransmittedStatus()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, TransmissionStatus.Failed);
+        CreateOrderFile(order.Id);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter
+            .Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandler(db, transmitter.Object);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<RetransmitOrderResponse>();
+        response.NewStatus.ShouldBe(TransmissionStatus.Transmitted);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionSucceeds_SetsTransmissionStatusChangedAt()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, TransmissionStatus.Failed);
+        CreateOrderFile(order.Id);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter
+            .Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandler(db, transmitter.Object);
+
+        var before = DateTime.UtcNow;
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+        var after = DateTime.UtcNow;
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatusChangedAt.ShouldNotBeNull();
+        saved.TransmissionStatusChangedAt.Value.ShouldBeGreaterThanOrEqualTo(before);
+        saved.TransmissionStatusChangedAt.Value.ShouldBeLessThanOrEqualTo(after);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionFails_StatusRemainsFailedWithUpdatedTimestamp()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, TransmissionStatus.Failed);
+        CreateOrderFile(order.Id);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter
+            .Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var handler = CreateHandler(db, transmitter.Object);
+
+        var before = DateTime.UtcNow;
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+        var after = DateTime.UtcNow;
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatus.ShouldBe(TransmissionStatus.Failed);
+        saved.TransmissionStatusChangedAt.ShouldNotBeNull();
+        saved.TransmissionStatusChangedAt.Value.ShouldBeGreaterThanOrEqualTo(before);
+        saved.TransmissionStatusChangedAt.Value.ShouldBeLessThanOrEqualTo(after);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionThrows_StatusRemainsFailedWithUpdatedTimestamp()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, TransmissionStatus.Failed);
+        CreateOrderFile(order.Id);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter
+            .Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("FTP error"));
+
+        var handler = CreateHandler(db, transmitter.Object);
+
+        var before = DateTime.UtcNow;
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+        var after = DateTime.UtcNow;
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatus.ShouldBe(TransmissionStatus.Failed);
+        saved.TransmissionStatusChangedAt.ShouldNotBeNull();
+        saved.TransmissionStatusChangedAt.Value.ShouldBeGreaterThanOrEqualTo(before);
+        saved.TransmissionStatusChangedAt.Value.ShouldBeLessThanOrEqualTo(after);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionSucceeds_CallsTransmitterWithCorrectFileName()
+    {
+        using var db = CreateDb();
+        var order = await SeedOrderAsync(db, customerId: 1, TransmissionStatus.Failed);
+        CreateOrderFile(order.Id);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter
+            .Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandler(db, transmitter.Object);
+
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var expectedFileName = $"EXT-{order.Id.ToString().PadLeft(10, '0')}.TXT";
+        transmitter.Verify(
+            t => t.TransmitAsync(It.IsAny<string>(), expectedFileName, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `POST /orders/{orderId}/retransmit` API endpoint that immediately attempts FTP retransmission for a `Failed` order, reusing the same file-lookup and FTP logic as the daily job
- Adds a **Retransmit** button on My Recent Orders (visible only for `Failed` orders), with an inline confirmation prompt and dismissible outcome alert
- Returns 404 for unknown/unauthorized orders and 409 for orders not in `Failed` status

## Test plan

- [x] Retransmit button appears only for `Failed` orders, not `Pending`, `Transmitted`, or `Missing`
- [x] Clicking Retransmit shows inline confirmation ("Retransmit this order? Yes / No")
- [x] Clicking No dismisses the confirmation without any action
- [x] On success: status updates to `Transmitted` and a green success alert is shown
- [x] On missing file: status updates to `Missing` and a yellow warning alert is shown
- [x] On FTP failure: status remains `Failed` with updated timestamp and a red failure alert is shown
- [x] All 14 new `RetransmitOrderHandlerTests` pass

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)