### PR TITLE
Re-create missing order file (issue #121)

### DIFF
--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpointExtensions.cs
@@ -5,6 +5,7 @@ using WidgetDepot.ApiService.Features.Orders.GetByOrderNumber;
 using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.GetDrafts;
 using WidgetDepot.ApiService.Features.Orders.GetRecentSubmitted;
+using WidgetDepot.ApiService.Features.Orders.RecreateOrder;
 using WidgetDepot.ApiService.Features.Orders.RetransmitOrder;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
 using WidgetDepot.ApiService.Features.Orders.Submit;
@@ -27,6 +28,7 @@ public static class OrderEndpointExtensions
         app.MapGetRecentSubmitted();
         app.MapGetByOrderNumber();
         app.MapRetransmitOrder();
+        app.MapRecreateOrder();
 
         return app;
     }

--- a/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/OrderEndpoints.cs
@@ -15,4 +15,5 @@ public static class OrderEndpoints
     public const string GetRecentSubmitted = $"{Base}/recent";
     public const string GetByOrderNumber = $"{Base}/{{orderNumber}}";
     public const string RetransmitOrder = $"{Base}/{{orderId}}/retransmit";
+    public const string RecreateOrder = $"{Base}/{{orderId}}/recreate";
 }

--- a/src/WidgetDepot.ApiService/Features/Orders/RecreateOrder/RecreateOrderEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/RecreateOrder/RecreateOrderEndpoint.cs
@@ -1,0 +1,33 @@
+using System.Security.Claims;
+
+namespace WidgetDepot.ApiService.Features.Orders.RecreateOrder;
+
+public static class RecreateOrderEndpoint
+{
+    public static IEndpointRouteBuilder MapRecreateOrder(this IEndpointRouteBuilder app)
+    {
+        app.MapPost(OrderEndpoints.RecreateOrder, async (
+            int orderId,
+            ClaimsPrincipal user,
+            RecreateOrderHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            if (!user.TryGetCustomerId(out var customerId))
+                return Results.Unauthorized();
+
+            var result = await handler.HandleAsync(orderId, customerId, cancellationToken);
+
+            return result switch
+            {
+                RecreateOrderNotFound => Results.NotFound(),
+                RecreateOrderInvalidStatus => Results.Conflict(),
+                RecreateOrderResponse response => Results.Ok(response),
+                _ => Results.Problem(statusCode: 500)
+            };
+        })
+        .WithName("RecreateOrder")
+        .RequireAuthorization();
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/RecreateOrder/RecreateOrderHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/RecreateOrder/RecreateOrderHandler.cs
@@ -1,0 +1,78 @@
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.Submit;
+using WidgetDepot.ApiService.Features.Orders.TransmitOrders;
+
+namespace WidgetDepot.ApiService.Features.Orders.RecreateOrder;
+
+public record RecreateOrderResponse(TransmissionStatus NewStatus, DateTime StatusChangedAt, string? ErrorMessage = null);
+public record RecreateOrderNotFound;
+public record RecreateOrderInvalidStatus;
+
+public class RecreateOrderHandler
+{
+    private readonly AppDbContext _db;
+    private readonly IOrderFileWriter _orderFileWriter;
+    private readonly IOrderTransmitter _transmitter;
+    private readonly string _pickupDirectory;
+    private readonly ILogger<RecreateOrderHandler> _logger;
+
+    public RecreateOrderHandler(
+        AppDbContext db,
+        IOrderFileWriter orderFileWriter,
+        IOrderTransmitter transmitter,
+        IConfiguration configuration,
+        ILogger<RecreateOrderHandler> logger)
+    {
+        _db = db;
+        _orderFileWriter = orderFileWriter;
+        _transmitter = transmitter;
+        _pickupDirectory = configuration["Orders:PickupDirectory"] ?? "/tmp/orders";
+        _logger = logger;
+    }
+
+    public async Task<object> HandleAsync(int orderId, int customerId, CancellationToken cancellationToken)
+    {
+        var order = await _db.Orders
+            .Include(o => o.Items)
+                .ThenInclude(i => i.Widget)
+            .FirstOrDefaultAsync(o => o.Id == orderId && o.CustomerId == customerId, cancellationToken);
+
+        if (order is null)
+            return new RecreateOrderNotFound();
+
+        if (order.TransmissionStatus != TransmissionStatus.Missing)
+            return new RecreateOrderInvalidStatus();
+
+        var customer = await _db.Customers.FindAsync([customerId], cancellationToken);
+        if (customer is null)
+            return new RecreateOrderNotFound();
+
+        var orderFile = new OrderFile(order, customer.Email);
+        await _orderFileWriter.WriteAsync(orderFile, cancellationToken);
+
+        var localFilePath = Path.Combine(_pickupDirectory, orderFile.FileName);
+
+        bool success;
+        string? errorMessage = null;
+        try
+        {
+            success = await _transmitter.TransmitAsync(localFilePath, orderFile.FileName, cancellationToken);
+            if (!success)
+                errorMessage = "FTP transmission failed.";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "FTP transmission failed for order {OrderId}", order.Id);
+            success = false;
+            errorMessage = ex.Message;
+        }
+
+        order.TransmissionStatus = success ? TransmissionStatus.Transmitted : TransmissionStatus.Failed;
+        order.TransmissionStatusChangedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return new RecreateOrderResponse(order.TransmissionStatus.Value, order.TransmissionStatusChangedAt.Value, errorMessage);
+    }
+}

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -14,6 +14,7 @@ using WidgetDepot.ApiService.Features.Orders.GetByOrderNumber;
 using WidgetDepot.ApiService.Features.Orders.GetDraftOrder;
 using WidgetDepot.ApiService.Features.Orders.GetDrafts;
 using WidgetDepot.ApiService.Features.Orders.GetRecentSubmitted;
+using WidgetDepot.ApiService.Features.Orders.RecreateOrder;
 using WidgetDepot.ApiService.Features.Orders.RetransmitOrder;
 using WidgetDepot.ApiService.Features.Orders.SaveAddresses;
 using WidgetDepot.ApiService.Features.Orders.Submit;
@@ -78,6 +79,7 @@ builder.Services.AddScoped<GetByOrderNumberHandler>();
 builder.Services.AddScoped<IOrderTransmitter, FtpOrderTransmitter>();
 builder.Services.AddScoped<TransmitOrdersHandler>();
 builder.Services.AddScoped<RetransmitOrderHandler>();
+builder.Services.AddScoped<RecreateOrderHandler>();
 builder.Services.AddHostedService<ExpireDraftOrdersJob>();
 builder.Services.AddHostedService<TransmitOrdersJob>();
 

--- a/src/WidgetDepot.Web/Features/Orders/History/HistoryModels.cs
+++ b/src/WidgetDepot.Web/Features/Orders/History/HistoryModels.cs
@@ -39,3 +39,12 @@ public abstract record RetransmitResult
     public record Failed : RetransmitResult;
     public record Failure : RetransmitResult;
 }
+
+internal record RecreateOrderApiResponse(TransmissionStatus NewStatus, DateTime StatusChangedAt, string? ErrorMessage = null);
+
+public abstract record RecreateResult
+{
+    public record Transmitted : RecreateResult;
+    public record Failed(string ErrorMessage) : RecreateResult;
+    public record Failure : RecreateResult;
+}

--- a/src/WidgetDepot.Web/Features/Orders/History/HistoryPage.razor
+++ b/src/WidgetDepot.Web/Features/Orders/History/HistoryPage.razor
@@ -76,6 +76,21 @@ else
                                 </button>
                             }
                         }
+                        @if (order.TransmissionStatus == TransmissionStatus.Missing)
+                        {
+                            @if (confirmingRecreateOrderId == order.Id)
+                            {
+                                <span class="ms-2 me-1">Re-create and retransmit this order?</span>
+                                <button class="btn btn-sm btn-warning me-1" @onclick="() => ConfirmRecreateAsync(order.Id)">Yes</button>
+                                <button class="btn btn-sm btn-secondary" @onclick="CancelRecreate">No</button>
+                            }
+                            else
+                            {
+                                <button class="btn btn-sm btn-warning ms-1" @onclick="() => RequestRecreate(order.Id)">
+                                    Re-create
+                                </button>
+                            }
+                        }
                     </td>
                 </tr>
             }
@@ -92,6 +107,7 @@ else
     private bool loadFailed;
 
     private int? confirmingOrderId;
+    private int? confirmingRecreateOrderId;
     private string? retransmitMessage;
     private string retransmitMessageClass = "alert-success";
 
@@ -128,6 +144,17 @@ else
         confirmingOrderId = null;
     }
 
+    private void RequestRecreate(int orderId)
+    {
+        confirmingRecreateOrderId = orderId;
+        retransmitMessage = null;
+    }
+
+    private void CancelRecreate()
+    {
+        confirmingRecreateOrderId = null;
+    }
+
     private void DismissRetransmitMessage()
     {
         retransmitMessage = null;
@@ -154,6 +181,31 @@ else
             case RetransmitResult.Failed:
                 retransmitMessageClass = "alert-danger";
                 retransmitMessage = "Retransmission failed. Please try again later.";
+                await RefreshOrdersAsync();
+                break;
+            default:
+                retransmitMessageClass = "alert-danger";
+                retransmitMessage = "An error occurred. Please try again later.";
+                break;
+        }
+    }
+
+    private async Task ConfirmRecreateAsync(int orderId)
+    {
+        confirmingRecreateOrderId = null;
+
+        var result = await HistoryService.RecreateOrderAsync(orderId);
+
+        switch (result)
+        {
+            case RecreateResult.Transmitted:
+                retransmitMessageClass = "alert-success";
+                retransmitMessage = "Order file successfully re-created and transmitted.";
+                await RefreshOrdersAsync();
+                break;
+            case RecreateResult.Failed failed:
+                retransmitMessageClass = "alert-danger";
+                retransmitMessage = $"Re-creation failed: {failed.ErrorMessage}";
                 await RefreshOrdersAsync();
                 break;
             default:

--- a/src/WidgetDepot.Web/Features/Orders/History/HistoryService.cs
+++ b/src/WidgetDepot.Web/Features/Orders/History/HistoryService.cs
@@ -34,6 +34,27 @@ public class HistoryService
         return new RetransmitResult.Failure();
     }
 
+    public async Task<RecreateResult> RecreateOrderAsync(int orderId, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.PostAsync($"/orders/{orderId}/recreate", null, cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var result = await response.Content.ReadFromJsonAsync<RecreateOrderApiResponse>(cancellationToken);
+            if (result is null)
+                return new RecreateResult.Failure();
+
+            return result.NewStatus switch
+            {
+                TransmissionStatus.Transmitted => new RecreateResult.Transmitted(),
+                TransmissionStatus.Failed => new RecreateResult.Failed(result.ErrorMessage ?? "FTP transmission failed."),
+                _ => new RecreateResult.Failure()
+            };
+        }
+
+        return new RecreateResult.Failure();
+    }
+
     public async Task<GetRecentOrdersResult> GetRecentOrdersAsync(CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.GetAsync("/orders/recent", cancellationToken);

--- a/tests/WidgetDepot.Tests/Features/Orders/History/HistoryServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/History/HistoryServiceTests.cs
@@ -123,6 +123,49 @@ public class HistoryServiceTests
         success.Orders[0].ShippingEstimate.ShouldBeNull();
     }
 
+    [Fact]
+    public async Task RecreateOrderAsync_SuccessTransmitted_ReturnsTransmitted()
+    {
+        var body = """{"newStatus":1,"statusChangedAt":"2026-05-30T10:00:00","errorMessage":null}""";
+        var service = CreateService(HttpStatusCode.OK, body);
+
+        var result = await service.RecreateOrderAsync(1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RecreateResult.Transmitted>();
+    }
+
+    [Fact]
+    public async Task RecreateOrderAsync_SuccessWithFailedStatus_ReturnsFailedWithErrorMessage()
+    {
+        var body = """{"newStatus":2,"statusChangedAt":"2026-05-30T10:00:00","errorMessage":"FTP transmission failed."}""";
+        var service = CreateService(HttpStatusCode.OK, body);
+
+        var result = await service.RecreateOrderAsync(1, TestContext.Current.CancellationToken);
+
+        var failed = result.ShouldBeOfType<RecreateResult.Failed>();
+        failed.ErrorMessage.ShouldBe("FTP transmission failed.");
+    }
+
+    [Fact]
+    public async Task RecreateOrderAsync_ServerError_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.InternalServerError, "{}");
+
+        var result = await service.RecreateOrderAsync(1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RecreateResult.Failure>();
+    }
+
+    [Fact]
+    public async Task RecreateOrderAsync_Conflict_ReturnsFailure()
+    {
+        var service = CreateService(HttpStatusCode.Conflict, "{}");
+
+        var result = await service.RecreateOrderAsync(1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RecreateResult.Failure>();
+    }
+
     private class FakeHttpMessageHandler(HttpStatusCode statusCode, string body) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/tests/WidgetDepot.Tests/Features/Orders/RecreateOrder/RecreateOrderHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/RecreateOrder/RecreateOrderHandlerTests.cs
@@ -1,0 +1,302 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Orders.RecreateOrder;
+using WidgetDepot.ApiService.Features.Orders.Submit;
+using WidgetDepot.ApiService.Features.Orders.TransmitOrders;
+
+namespace WidgetDepot.Tests.Features.Orders.RecreateOrder;
+
+public class RecreateOrderHandlerTests
+{
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static RecreateOrderHandler CreateHandler(
+        AppDbContext db,
+        IOrderFileWriter? writer = null,
+        IOrderTransmitter? transmitter = null)
+    {
+        var mockWriter = writer ?? new Mock<IOrderFileWriter>().Object;
+        var mockTransmitter = transmitter ?? new Mock<IOrderTransmitter>().Object;
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Orders:PickupDirectory"] = "/tmp/orders" })
+            .Build();
+        var logger = new Mock<ILogger<RecreateOrderHandler>>().Object;
+        return new RecreateOrderHandler(db, mockWriter, mockTransmitter, config, logger);
+    }
+
+    private static async Task<(Order order, Customer customer)> SeedMissingOrderAsync(AppDbContext db, int customerId = 1)
+    {
+        var customer = new Customer
+        {
+            Id = customerId,
+            FirstName = "Alice",
+            LastName = "Smith",
+            Email = "alice@example.com",
+            PasswordHash = "hash",
+            CreatedAt = DateTime.UtcNow
+        };
+        db.Customers.Add(customer);
+
+        var widget = new Widget { Id = 1, Sku = "W-001", Name = "Sprocket", Weight = 1.5m };
+        db.Widgets.Add(widget);
+
+        var order = new Order
+        {
+            CustomerId = customerId,
+            Status = OrderStatus.Submitted,
+            CreatedAt = DateTime.UtcNow,
+            SubmittedAt = DateTime.UtcNow,
+            TransmissionStatus = TransmissionStatus.Missing,
+            ShippingAddress = new Address
+            {
+                RecipientName = "Alice Smith",
+                StreetLine1 = "123 Main St",
+                City = "Springfield",
+                State = "IL",
+                ZipCode = "62701"
+            },
+            BillingAddress = new Address
+            {
+                RecipientName = "Alice Smith",
+                StreetLine1 = "456 Oak Ave",
+                City = "Shelbyville",
+                State = "IL",
+                ZipCode = "62565"
+            }
+        };
+        order.Items.Add(new OrderItem { WidgetId = widget.Id, Quantity = 2 });
+        db.Orders.Add(order);
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return (order, customer);
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderNotFound_ReturnsNotFound()
+    {
+        using var db = CreateDb();
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(999, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RecreateOrderNotFound>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderBelongsToDifferentCustomer_ReturnsNotFound()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedMissingOrderAsync(db, customerId: 1);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 2, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RecreateOrderNotFound>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderStatusIsPending_ReturnsInvalidStatus()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedMissingOrderAsync(db);
+        order.TransmissionStatus = TransmissionStatus.Pending;
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RecreateOrderInvalidStatus>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderStatusIsTransmitted_ReturnsInvalidStatus()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedMissingOrderAsync(db);
+        order.TransmissionStatus = TransmissionStatus.Transmitted;
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RecreateOrderInvalidStatus>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_OrderStatusIsFailed_ReturnsInvalidStatus()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedMissingOrderAsync(db);
+        order.TransmissionStatus = TransmissionStatus.Failed;
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = CreateHandler(db);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<RecreateOrderInvalidStatus>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionSucceeds_SetsStatusToTransmitted()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedMissingOrderAsync(db);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter.Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandler(db, transmitter: transmitter.Object);
+
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatus.ShouldBe(TransmissionStatus.Transmitted);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionSucceeds_ReturnsResponseWithTransmittedStatus()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedMissingOrderAsync(db);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter.Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandler(db, transmitter: transmitter.Object);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<RecreateOrderResponse>();
+        response.NewStatus.ShouldBe(TransmissionStatus.Transmitted);
+        response.ErrorMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionSucceeds_SetsTransmissionStatusChangedAt()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedMissingOrderAsync(db);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter.Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandler(db, transmitter: transmitter.Object);
+
+        var before = DateTime.UtcNow;
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+        var after = DateTime.UtcNow;
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatusChangedAt.ShouldNotBeNull();
+        saved.TransmissionStatusChangedAt.Value.ShouldBeGreaterThanOrEqualTo(before);
+        saved.TransmissionStatusChangedAt.Value.ShouldBeLessThanOrEqualTo(after);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionSucceeds_CallsFileWriter()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedMissingOrderAsync(db);
+
+        var writer = new Mock<IOrderFileWriter>();
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter.Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = CreateHandler(db, writer.Object, transmitter.Object);
+
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        writer.Verify(w => w.WriteAsync(It.IsAny<OrderFile>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionFails_SetsStatusToFailed()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedMissingOrderAsync(db);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter.Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var handler = CreateHandler(db, transmitter: transmitter.Object);
+
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatus.ShouldBe(TransmissionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionFails_ReturnsResponseWithFailedStatusAndErrorMessage()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedMissingOrderAsync(db);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter.Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var handler = CreateHandler(db, transmitter: transmitter.Object);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<RecreateOrderResponse>();
+        response.NewStatus.ShouldBe(TransmissionStatus.Failed);
+        response.ErrorMessage.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionThrows_SetsStatusToFailed()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedMissingOrderAsync(db);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter.Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("FTP error"));
+
+        var handler = CreateHandler(db, transmitter: transmitter.Object);
+
+        await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var saved = await db.Orders.FirstAsync(TestContext.Current.CancellationToken);
+        saved.TransmissionStatus.ShouldBe(TransmissionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TransmissionThrows_ReturnsResponseWithErrorMessage()
+    {
+        using var db = CreateDb();
+        var (order, _) = await SeedMissingOrderAsync(db);
+
+        var transmitter = new Mock<IOrderTransmitter>();
+        transmitter.Setup(t => t.TransmitAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("FTP error"));
+
+        var handler = CreateHandler(db, transmitter: transmitter.Object);
+
+        var result = await handler.HandleAsync(order.Id, customerId: 1, TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<RecreateOrderResponse>();
+        response.NewStatus.ShouldBe(TransmissionStatus.Failed);
+        response.ErrorMessage.ShouldBe("FTP error");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `POST /orders/{orderId}/recreate` API endpoint that regenerates the ERP order file from stored DB data and immediately retransmits via FTP for orders with `Missing` transmission status
- Shows a **Re-create** button on My Recent Orders only for `Missing` orders, with a confirmation prompt before proceeding
- On success sets status to `Transmitted` and shows a confirmation message; on FTP failure sets status to `Failed` and shows the error message to the customer

## Test plan

- [x] All 288 unit tests pass (`dotnet test`)
- [x] Re-create button visible only for orders with `Missing` status (not Pending, Transmitted, or Failed)
- [x] Clicking Re-create shows confirmation prompt; clicking No dismisses without action
- [x] Clicking Yes on confirmation regenerates file and retransmits; success message shown and status updated to `Transmitted`
- [x] If FTP transmission fails, status set to `Failed` and error message shown
- [x] Orders with `Pending`, `Transmitted`, or `Failed` status show no Re-create button

Closes #121