### PR TITLE
Fix auth setup

### DIFF
--- a/tests/WidgetDepot.E2E/tests/catalog.spec.ts
+++ b/tests/WidgetDepot.E2E/tests/catalog.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from './fixtures';
 
 test.describe('Catalog page', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
   // AC #1: Unauthenticated visitor can navigate to catalog without redirect
   test('unauthenticated visitor can access catalog without being redirected to login', async ({ catalogPage }) => {
     await catalogPage.goto();

--- a/tests/WidgetDepot.E2E/tests/fixtures/auth.ts
+++ b/tests/WidgetDepot.E2E/tests/fixtures/auth.ts
@@ -11,7 +11,10 @@ export const authTest = base.extend<{}, { workerStorageState: string }>({
 
     if (!fs.existsSync(fileName)) {
       fs.mkdirSync(STORAGE_STATE_DIR, { recursive: true });
-      const context = await browser.newContext();
+      const context = await browser.newContext({
+        baseURL: 'https://localhost:7092',
+        ignoreHTTPSErrors: true,
+      });
       const page = await context.newPage();
       const loginPage = new LoginPage(page);
       await loginPage.goto();

--- a/tests/WidgetDepot.E2E/tests/fixtures/index.ts
+++ b/tests/WidgetDepot.E2E/tests/fixtures/index.ts
@@ -2,5 +2,5 @@ import { mergeTests } from '@playwright/test';
 import { pagesTest } from './pages';
 import { authTest } from './auth';
 
-export const test = pagesTest;
+export const test = mergeTests(pagesTest, authTest);
 export { expect } from '@playwright/test';

--- a/tests/WidgetDepot.E2E/tests/logout.spec.ts
+++ b/tests/WidgetDepot.E2E/tests/logout.spec.ts
@@ -2,19 +2,15 @@ import { test, expect } from './fixtures';
 
 test.describe('Customer logout', () => {
   // AC #3: Logged-in customer can log out and is redirected to home page
-  test('redirects to home page after signing out', async ({ loginPage, navBar, page }) => {
-    await loginPage.goto();
-    await loginPage.login(process.env.E2E_EMAIL!, process.env.E2E_PASSWORD!);
-    await expect(page).toHaveURL('/');
+  test('redirects to home page after signing out', async ({ homePage, navBar, page }) => {
+    await homePage.goto();
     await navBar.signOut();
     await expect(page).toHaveURL('/');
   });
 
   // AC #3: After logout, authenticated routes are no longer accessible
-  test('cannot access authenticated routes after signing out', async ({ loginPage, navBar, page }) => {
-    await loginPage.goto();
-    await loginPage.login(process.env.E2E_EMAIL!, process.env.E2E_PASSWORD!);
-    await expect(page).toHaveURL('/');
+  test('cannot access authenticated routes after signing out', async ({ homePage, navBar, page }) => {
+    await homePage.goto();
     await navBar.signOut();
     await page.goto('/accounts/profile');
     await expect(page).toHaveURL(/\/accounts\/login/);

--- a/tests/WidgetDepot.E2E/tests/register.spec.ts
+++ b/tests/WidgetDepot.E2E/tests/register.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from './fixtures';
 
 test.describe('Customer self-registration', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
   // AC #1: Visitor can navigate to /accounts/register without being redirected to login
   test('unauthenticated visitor can access registration page without redirect', async ({ registerPage }) => {
     await registerPage.goto();


### PR DESCRIPTION
## Summary

- Wire `authTest` into the merged fixture so worker-scoped storage state is shared across specs
- Fix auth setup context to pass `baseURL` and `ignoreHTTPSErrors` when creating the unauthenticated browser context
- Simplify logout tests to use the auth fixture rather than repeating inline login steps
- Mark catalog and register specs as unauthenticated via `test.use({ storageState: ... })`

## Test plan

- [ ] Run `npm test --prefix tests/WidgetDepot.E2E` and confirm all specs pass
- [ ] Verify logout tests redirect to home page after sign-out
- [ ] Verify catalog and register specs remain accessible without authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)