### PR TITLE
Admin area setup (#134)

### DIFF
--- a/src/WidgetDepot.ApiService/Data/Customer.cs
+++ b/src/WidgetDepot.ApiService/Data/Customer.cs
@@ -8,6 +8,7 @@ public class Customer
     public string Email { get; set; } = string.Empty;
     public string PasswordHash { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
+    public bool IsAdmin { get; set; }
     public Address? ShippingAddress { get; set; }
     public Address? BillingAddress { get; set; }
 }

--- a/src/WidgetDepot.ApiService/Data/Migrations/20260611083542_AddIsAdminToCustomer.Designer.cs
+++ b/src/WidgetDepot.ApiService/Data/Migrations/20260611083542_AddIsAdminToCustomer.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WidgetDepot.ApiService.Data;
@@ -11,9 +12,11 @@ using WidgetDepot.ApiService.Data;
 namespace WidgetDepot.ApiService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260611083542_AddIsAdminToCustomer")]
+    partial class AddIsAdminToCustomer
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WidgetDepot.ApiService/Data/Migrations/20260611083542_AddIsAdminToCustomer.cs
+++ b/src/WidgetDepot.ApiService/Data/Migrations/20260611083542_AddIsAdminToCustomer.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WidgetDepot.ApiService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsAdminToCustomer : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsAdmin",
+                table: "Customers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsAdmin",
+                table: "Customers");
+        }
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Accounts/Login/LoginHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Accounts/Login/LoginHandler.cs
@@ -7,7 +7,7 @@ namespace WidgetDepot.ApiService.Features.Accounts.Login;
 
 public record LoginRequest(string Email, string Password);
 
-public record LoginResponse(int CustomerId, string Email, string FirstName);
+public record LoginResponse(int CustomerId, string Email, string FirstName, bool IsAdmin);
 
 public abstract record LoginError
 {
@@ -34,7 +34,7 @@ public class LoginHandler(AppDbContext db)
             if (result == PasswordVerificationResult.Failed)
                 return new LoginError.InvalidCredentials();
 
-            return new LoginResponse(customer.Id, customer.Email, customer.FirstName);
+            return new LoginResponse(customer.Id, customer.Email, customer.FirstName, customer.IsAdmin);
         }
         catch (Exception ex)
         {

--- a/src/WidgetDepot.ApiService/Features/Admin/Seed/AdminSeedOptions.cs
+++ b/src/WidgetDepot.ApiService/Features/Admin/Seed/AdminSeedOptions.cs
@@ -1,0 +1,12 @@
+namespace WidgetDepot.ApiService.Features.Admin.Seed;
+
+public class AdminSeedOptions
+{
+    public SeedCredentials? SeedCredentials { get; set; }
+}
+
+public class SeedCredentials
+{
+    public string UserName { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/src/WidgetDepot.ApiService/Features/Admin/Seed/AdminSeeder.cs
+++ b/src/WidgetDepot.ApiService/Features/Admin/Seed/AdminSeeder.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Admin.Seed;
+
+public class AdminSeeder(AppDbContext db, IOptions<AdminSeedOptions> options, ILogger<AdminSeeder> logger)
+{
+    private readonly PasswordHasher<Customer> _passwordHasher = new();
+
+    public async Task SeedAsync(CancellationToken cancellationToken)
+    {
+        var credentials = options.Value.SeedCredentials;
+
+        if (credentials is null || string.IsNullOrWhiteSpace(credentials.UserName) || string.IsNullOrWhiteSpace(credentials.Password))
+        {
+            logger.LogWarning("Admin seed credentials are not configured. Skipping admin user seeding.");
+            return;
+        }
+
+        var exists = await db.Customers
+            .AnyAsync(c => c.Email == credentials.UserName, cancellationToken);
+
+        if (exists)
+            return;
+
+        var admin = new Customer
+        {
+            FirstName = "Admin",
+            LastName = "User",
+            Email = credentials.UserName,
+            IsAdmin = true,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        admin.PasswordHash = _passwordHasher.HashPassword(admin, credentials.Password);
+
+        db.Customers.Add(admin);
+        await db.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation("Admin user '{UserName}' created.", credentials.UserName);
+    }
+}

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -6,6 +6,7 @@ using WidgetDepot.ApiService.Features.Accounts.Login;
 using WidgetDepot.ApiService.Features.Accounts.PasswordChange;
 using WidgetDepot.ApiService.Features.Accounts.Profile;
 using WidgetDepot.ApiService.Features.Accounts.Register;
+using WidgetDepot.ApiService.Features.Admin.Seed;
 using WidgetDepot.ApiService.Features.Orders;
 using WidgetDepot.ApiService.Features.Orders.CalculateShipping;
 using WidgetDepot.ApiService.Features.Orders.CreateDraft;
@@ -49,7 +50,14 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
             return Task.CompletedTask;
         };
     });
-builder.Services.AddAuthorization();
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("IsAdmin", policy =>
+        policy.RequireClaim("IsAdmin", "true"));
+});
+
+builder.Services.Configure<AdminSeedOptions>(builder.Configuration.GetSection("Admin"));
+builder.Services.AddScoped<AdminSeeder>();
 
 builder.AddNpgsqlDbContext<AppDbContext>("widgetdepot");
 
@@ -90,11 +98,14 @@ builder.Services.AddOpenApi();
 
 var app = builder.Build();
 
-// Apply migrations at startup
+// Apply migrations and seed at startup
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
     await db.Database.MigrateAsync();
+
+    var seeder = scope.ServiceProvider.GetRequiredService<AdminSeeder>();
+    await seeder.SeedAsync(CancellationToken.None);
 }
 
 // Configure the HTTP request pipeline.

--- a/src/WidgetDepot.ApiService/appsettings.Development.json
+++ b/src/WidgetDepot.ApiService/appsettings.Development.json
@@ -7,7 +7,7 @@
   },
   "Admin": {
     "SeedCredentials": {
-      "UserName": "admin",
+      "UserName": "admin@example.com",
       "Password": "P@ssw0rd"
     }
   }

--- a/src/WidgetDepot.ApiService/appsettings.Development.json
+++ b/src/WidgetDepot.ApiService/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Admin": {
+    "SeedCredentials": {
+      "UserName": "admin",
+      "Password": "P@ssw0rd"
+    }
   }
 }

--- a/src/WidgetDepot.Web/Components/Layout/AdminLayout.razor
+++ b/src/WidgetDepot.Web/Components/Layout/AdminLayout.razor
@@ -1,0 +1,59 @@
+@inherits LayoutComponentBase
+
+<div class="page">
+    <div class="sidebar admin-sidebar">
+        <div class="top-row ps-3 navbar navbar-dark bg-dark">
+            <div class="container-fluid">
+                <a class="navbar-brand" href="/admin">WidgetDepot Admin</a>
+            </div>
+        </div>
+
+        <input type="checkbox" title="Navigation menu" class="navbar-toggler" />
+
+        <div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
+            <nav class="nav flex-column">
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="admin/users">
+                        <span class="bi bi-people-fill" aria-hidden="true"></span> Users
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="orders/lookup">
+                        <span class="bi bi-search" aria-hidden="true"></span> Order Lookup
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="admin/catalog-import">
+                        <span class="bi bi-upload" aria-hidden="true"></span> Catalog Upload
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3 mt-3">
+                    <a class="nav-link" href="/accounts/logout">
+                        <span class="bi bi-box-arrow-right" aria-hidden="true"></span> Sign Out
+                    </a>
+                </div>
+            </nav>
+        </div>
+    </div>
+
+    <main>
+        <div class="top-row px-4 bg-dark text-white">
+            <AuthorizeView>
+                <Authorized>
+                    <span class="me-2">@context.User.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value</span>
+                    <span class="badge bg-warning text-dark">Admin</span>
+                </Authorized>
+            </AuthorizeView>
+        </div>
+
+        <article class="content px-4">
+            @Body
+        </article>
+    </main>
+</div>
+
+<div id="blazor-error-ui">
+    An unhandled error has occurred.
+    <a href="" class="reload">Reload</a>
+    <a class="dismiss">🗙</a>
+</div>

--- a/src/WidgetDepot.Web/Components/Layout/AdminLayout.razor.css
+++ b/src/WidgetDepot.Web/Components/Layout/AdminLayout.razor.css
@@ -1,0 +1,187 @@
+.page {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+main {
+    flex: 1;
+}
+
+.sidebar {
+    background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
+}
+
+.top-row {
+    background-color: #f7f7f7;
+    border-bottom: 1px solid #d6d5d5;
+    justify-content: flex-end;
+    height: 3.5rem;
+    display: flex;
+    align-items: center;
+}
+
+    .top-row ::deep a, .top-row ::deep .btn-link {
+        white-space: nowrap;
+        margin-left: 1.5rem;
+        text-decoration: none;
+    }
+
+    .top-row ::deep a:hover, .top-row ::deep .btn-link:hover {
+        text-decoration: underline;
+    }
+
+    .top-row ::deep a:first-child {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+.navbar-toggler {
+    appearance: none;
+    cursor: pointer;
+    width: 3.5rem;
+    height: 2.5rem;
+    color: white;
+    position: absolute;
+    top: 0.5rem;
+    right: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.55%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") no-repeat center/1.75rem rgba(255, 255, 255, 0.1);
+}
+
+.navbar-toggler:checked {
+    background-color: rgba(255, 255, 255, 0.5);
+}
+
+.navbar-brand {
+    font-size: 1.1rem;
+}
+
+.nav-item {
+    font-size: 0.9rem;
+    padding-bottom: 0.5rem;
+}
+
+    .nav-item:first-of-type {
+        padding-top: 1rem;
+    }
+
+    .nav-item:last-of-type {
+        padding-bottom: 1rem;
+    }
+
+    .nav-item ::deep a {
+        color: #d7d7d7;
+        border-radius: 4px;
+        height: 3rem;
+        display: flex;
+        align-items: center;
+        line-height: 3rem;
+    }
+
+.nav-item ::deep a.active {
+    background-color: rgba(255,255,255,0.37);
+    color: white;
+}
+
+.nav-item ::deep a:hover {
+    background-color: rgba(255,255,255,0.1);
+    color: white;
+}
+
+.nav-scrollable {
+    display: none;
+}
+
+.navbar-toggler:checked ~ .nav-scrollable {
+    display: block;
+}
+
+.bi {
+    display: inline-block;
+    position: relative;
+    width: 1.25rem;
+    height: 1.25rem;
+    margin-right: 0.75rem;
+    top: -1px;
+    background-size: cover;
+}
+
+.bi-people-fill {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-people-fill' viewBox='0 0 16 16'%3E%3Cpath d='M7 14s-1 0-1-1 1-4 5-4 5 3 5 4-1 1-1 1H7zm4-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6z'/%3E%3Cpath fill-rule='evenodd' d='M5.216 14A2.238 2.238 0 0 1 5 13c0-1.355.68-2.75 1.936-3.72A6.325 6.325 0 0 0 5 9c-4 0-5 3-5 4s1 1 1 1h4.216z'/%3E%3Cpath d='M4.5 8a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z'/%3E%3C/svg%3E");
+}
+
+.bi-search {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-search' viewBox='0 0 16 16'%3E%3Cpath d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.099zm-5.242 1.656a5.5 5.5 0 1 1 0-11 5.5 5.5 0 0 1 0 11z'/%3E%3C/svg%3E");
+}
+
+.bi-upload {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-upload' viewBox='0 0 16 16'%3E%3Cpath d='M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z'/%3E%3Cpath d='M7.646 1.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 2.707V11.5a.5.5 0 0 1-1 0V2.707L5.354 4.854a.5.5 0 1 1-.708-.708l3-3z'/%3E%3C/svg%3E");
+}
+
+.bi-box-arrow-right {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-box-arrow-right' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0v2z'/%3E%3Cpath fill-rule='evenodd' d='M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3z'/%3E%3C/svg%3E");
+}
+
+@media (max-width: 640.98px) {
+    .top-row {
+        justify-content: space-between;
+    }
+
+    .top-row ::deep a, .top-row ::deep .btn-link {
+        margin-left: 0;
+    }
+}
+
+@media (min-width: 641px) {
+    .page {
+        flex-direction: row;
+    }
+
+    .sidebar {
+        width: 250px;
+        height: 100vh;
+        position: sticky;
+        top: 0;
+    }
+
+    .top-row {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+    }
+
+    .top-row, article {
+        padding-left: 2rem !important;
+        padding-right: 1.5rem !important;
+    }
+
+    .navbar-toggler {
+        display: none;
+    }
+
+    .nav-scrollable {
+        display: block;
+        height: calc(100vh - 3.5rem);
+        overflow-y: auto;
+    }
+}
+
+#blazor-error-ui {
+    background: lightyellow;
+    bottom: 0;
+    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    left: 0;
+    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+}
+
+    #blazor-error-ui .dismiss {
+        cursor: pointer;
+        position: absolute;
+        right: 0.75rem;
+        top: 0.5rem;
+    }

--- a/src/WidgetDepot.Web/Components/Layout/NavMenu.razor
+++ b/src/WidgetDepot.Web/Components/Layout/NavMenu.razor
@@ -18,12 +18,6 @@
                 <span class="bi bi-grid-fill" aria-hidden="true"></span> Catalog
             </NavLink>
         </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="admin/catalog-import">
-                <span class="bi bi-upload" aria-hidden="true"></span> Catalog Import
-            </NavLink>
-        </div>
-
         <AuthorizeView>
             <Authorized>
                 <div class="nav-item px-3">
@@ -39,6 +33,11 @@
                 <div class="nav-item px-3">
                     <NavLink class="nav-link" href="orders/history">
                         <span class="bi bi-clock-history" aria-hidden="true"></span> My Recent Orders
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="orders/lookup">
+                        <span class="bi bi-search" aria-hidden="true"></span> Order Lookup
                     </NavLink>
                 </div>
                 <div class="nav-item px-3">

--- a/src/WidgetDepot.Web/Components/Layout/NavMenu.razor
+++ b/src/WidgetDepot.Web/Components/Layout/NavMenu.razor
@@ -42,11 +42,6 @@
                     </NavLink>
                 </div>
                 <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="orders/lookup">
-                        <span class="bi bi-search" aria-hidden="true"></span> Order Lookup
-                    </NavLink>
-                </div>
-                <div class="nav-item px-3">
                     <NavLink class="nav-link" href="accounts/profile">
                         <span class="bi bi-person-fill" aria-hidden="true"></span> Profile
                     </NavLink>

--- a/src/WidgetDepot.Web/Components/RedirectToAccessDenied.razor
+++ b/src/WidgetDepot.Web/Components/RedirectToAccessDenied.razor
@@ -1,0 +1,8 @@
+@inject NavigationManager NavigationManager
+
+@code {
+    protected override void OnInitialized()
+    {
+        NavigationManager.NavigateTo("/access-denied", forceLoad: true);
+    }
+}

--- a/src/WidgetDepot.Web/Components/Routes.razor
+++ b/src/WidgetDepot.Web/Components/Routes.razor
@@ -2,7 +2,14 @@
     <Found Context="routeData">
         <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)">
             <NotAuthorized>
-                <RedirectToLogin />
+                @if (context.User.Identity?.IsAuthenticated == true)
+                {
+                    <RedirectToAccessDenied />
+                }
+                else
+                {
+                    <RedirectToLogin />
+                }
             </NotAuthorized>
         </AuthorizeRouteView>
         <FocusOnNavigate RouteData="routeData" Selector="h1" />

--- a/src/WidgetDepot.Web/Features/Accounts/AccessDenied/AccessDeniedPage.razor
+++ b/src/WidgetDepot.Web/Features/Accounts/AccessDenied/AccessDeniedPage.razor
@@ -1,0 +1,11 @@
+@page "/access-denied"
+
+<PageTitle>Access Denied</PageTitle>
+
+<div class="row justify-content-center mt-5">
+    <div class="col-md-6 text-center">
+        <h1>Access Denied</h1>
+        <p class="text-muted">You do not have permission to view this page.</p>
+        <a href="/" class="btn btn-primary">Return to Home</a>
+    </div>
+</div>

--- a/src/WidgetDepot.Web/Features/Accounts/Login/LoginModels.cs
+++ b/src/WidgetDepot.Web/Features/Accounts/Login/LoginModels.cs
@@ -12,7 +12,7 @@ public class LoginFormModel
     public string Password { get; set; } = string.Empty;
 }
 
-public record LoginResponse(int CustomerId, string Email, string FirstName);
+public record LoginResponse(int CustomerId, string Email, string FirstName, bool IsAdmin);
 
 public abstract record LoginResult
 {

--- a/src/WidgetDepot.Web/Features/Accounts/Login/LoginPage.razor
+++ b/src/WidgetDepot.Web/Features/Accounts/Login/LoginPage.razor
@@ -74,7 +74,7 @@
             switch (result)
             {
                 case LoginResult.Success success:
-                    var url = $"/accounts/do-signin?customerId={success.Customer.CustomerId}&email={Uri.EscapeDataString(success.Customer.Email)}&firstName={Uri.EscapeDataString(success.Customer.FirstName)}";
+                    var url = $"/accounts/do-signin?customerId={success.Customer.CustomerId}&email={Uri.EscapeDataString(success.Customer.Email)}&firstName={Uri.EscapeDataString(success.Customer.FirstName)}&isAdmin={success.Customer.IsAdmin}";
                     NavigationManager.NavigateTo(url, forceLoad: true);
                     break;
                 case LoginResult.InvalidCredentials:

--- a/src/WidgetDepot.Web/Features/Admin/AdminHomePage.razor
+++ b/src/WidgetDepot.Web/Features/Admin/AdminHomePage.razor
@@ -1,0 +1,7 @@
+@page "/admin"
+
+<PageTitle>Admin Home</PageTitle>
+
+<h1>Admin Dashboard</h1>
+
+Welcome to the WidgetDepot admin area.

--- a/src/WidgetDepot.Web/Features/Admin/_Imports.razor
+++ b/src/WidgetDepot.Web/Features/Admin/_Imports.razor
@@ -1,0 +1,4 @@
+@using Microsoft.AspNetCore.Authorization
+@using WidgetDepot.Web.Components.Layout
+@attribute [Authorize(Policy = "IsAdmin")]
+@layout AdminLayout

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -138,7 +138,7 @@ app.MapGet("/accounts/do-signin", async (HttpContext context, int customerId, st
     await context.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
     var target = !string.IsNullOrEmpty(returnUrl) && Uri.IsWellFormedUriString(returnUrl, UriKind.Relative)
         ? returnUrl
-        : "/";
+        : isAdmin ? "/admin" : "/";
     return Results.Redirect(target);
 });
 

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -33,8 +33,13 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
     .AddCookie(options =>
     {
         options.LoginPath = "/accounts/login";
+        options.AccessDeniedPath = "/access-denied";
     });
-builder.Services.AddAuthorization();
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("IsAdmin", policy =>
+        policy.RequireClaim("IsAdmin", "true"));
+});
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddTransient<CookieForwardingHandler>();
@@ -116,7 +121,7 @@ app.MapRazorComponents<App>()
 
 app.MapDefaultEndpoints();
 
-app.MapGet("/accounts/do-signin", async (HttpContext context, int customerId, string email, string firstName, string? returnUrl) =>
+app.MapGet("/accounts/do-signin", async (HttpContext context, int customerId, string email, string firstName, bool isAdmin, string? returnUrl) =>
 {
     var claims = new List<Claim>
     {
@@ -124,6 +129,10 @@ app.MapGet("/accounts/do-signin", async (HttpContext context, int customerId, st
         new(ClaimTypes.Email, email),
         new(ClaimTypes.Name, firstName)
     };
+
+    if (isAdmin)
+        claims.Add(new Claim("IsAdmin", "true"));
+
     var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
     var principal = new ClaimsPrincipal(identity);
     await context.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);

--- a/tests/WidgetDepot.Tests/Features/Accounts/Login/LoginHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Accounts/Login/LoginHandlerTests.cs
@@ -48,6 +48,31 @@ public class LoginHandlerTests
         response.Email.ShouldBe("jane@example.com");
         response.FirstName.ShouldBe("Jane");
         response.CustomerId.ShouldBeGreaterThan(0);
+        response.IsAdmin.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAsync_AdminUser_ReturnsIsAdminTrue()
+    {
+        using var db = CreateDb();
+        var hasher = new PasswordHasher<Customer>();
+        var admin = new Customer
+        {
+            FirstName = "Admin",
+            LastName = "User",
+            Email = "admin@example.com",
+            IsAdmin = true,
+            CreatedAt = DateTime.UtcNow
+        };
+        admin.PasswordHash = hasher.HashPassword(admin, "P@ssw0rd!");
+        db.Customers.Add(admin);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var handler = new LoginHandler(db);
+
+        var result = await handler.HandleAsync(new LoginRequest("admin@example.com", "P@ssw0rd!"), TestContext.Current.CancellationToken);
+
+        var response = result.ShouldBeOfType<LoginResponse>();
+        response.IsAdmin.ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/WidgetDepot.Tests/Features/Admin/Seed/AdminSeederTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Admin/Seed/AdminSeederTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Shouldly;
+
+using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.Admin.Seed;
+
+namespace WidgetDepot.Tests.Features.Admin.Seed;
+
+public class AdminSeederTests
+{
+    private static AppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static AdminSeeder CreateSeeder(AppDbContext db, AdminSeedOptions seedOptions)
+    {
+        var options = Options.Create(seedOptions);
+        var logger = NullLogger<AdminSeeder>.Instance;
+        return new AdminSeeder(db, options, logger);
+    }
+
+    [Fact]
+    public async Task SeedAsync_ValidCredentials_CreatesAdminUser()
+    {
+        using var db = CreateDb();
+        var seeder = CreateSeeder(db, new AdminSeedOptions
+        {
+            SeedCredentials = new SeedCredentials { UserName = "admin", Password = "P@ssw0rd" }
+        });
+        var ct = TestContext.Current.CancellationToken;
+
+        await seeder.SeedAsync(ct);
+
+        var admin = await db.Customers.SingleOrDefaultAsync(c => c.Email == "admin", ct);
+        admin.ShouldNotBeNull();
+        admin.IsAdmin.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task SeedAsync_RunTwice_DoesNotCreateDuplicate()
+    {
+        using var db = CreateDb();
+        var seeder = CreateSeeder(db, new AdminSeedOptions
+        {
+            SeedCredentials = new SeedCredentials { UserName = "admin", Password = "P@ssw0rd" }
+        });
+        var ct = TestContext.Current.CancellationToken;
+
+        await seeder.SeedAsync(ct);
+        await seeder.SeedAsync(ct);
+
+        var count = await db.Customers.CountAsync(c => c.Email == "admin", ct);
+        count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task SeedAsync_SeedCredentialsAbsent_SkipsSeeding()
+    {
+        using var db = CreateDb();
+        var seeder = CreateSeeder(db, new AdminSeedOptions { SeedCredentials = null });
+        var ct = TestContext.Current.CancellationToken;
+
+        await seeder.SeedAsync(ct);
+
+        var count = await db.Customers.CountAsync(ct);
+        count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task SeedAsync_EmptyUserName_SkipsSeeding()
+    {
+        using var db = CreateDb();
+        var seeder = CreateSeeder(db, new AdminSeedOptions
+        {
+            SeedCredentials = new SeedCredentials { UserName = "", Password = "P@ssw0rd" }
+        });
+        var ct = TestContext.Current.CancellationToken;
+
+        await seeder.SeedAsync(ct);
+
+        var count = await db.Customers.CountAsync(ct);
+        count.ShouldBe(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `IsAdmin` flag to the `Customers` table (EF Core migration, defaults `false` for existing records)
- Seeds an initial admin user at startup from `appsettings.json` `Admin:SeedCredentials`; skips gracefully with a warning if config is absent; guards against duplicate creation
- Extends `LoginResponse` with `IsAdmin` and includes an `IsAdmin` claim in the auth cookie when true
- Registers an `IsAdmin` authorization policy in both ApiService and Web
- `Features/Admin/_Imports.razor` applies the policy and `AdminLayout` to all admin pages
- `AdminLayout` has a dark navbar with links to Users, Order Lookup, and Catalog Upload
- Authenticated non-admin users navigating to `/admin/*` are redirected to a new `/access-denied` page; unauthenticated users are redirected to login

## Test plan

- [x] All 293 unit tests pass (`dotnet test`)
- [x] Log in as a regular user and navigate to `/admin/catalog-import` — redirected to `/access-denied`
- [x] Navigate to `/admin/catalog-import` while logged out — redirected to `/accounts/login`
- [x] Log in as `admin` / `P@ssw0rd` — can reach `/admin/catalog-import`, sees dark admin nav with Users / Order Lookup / Catalog Upload links
- [x] Restart the app twice — no duplicate admin user created in the database

Closes #134