### PR TITLE
Admin: Order Lookup (#137)

### DIFF
--- a/src/WidgetDepot.ApiService/Features/Admin/AdminEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Admin/AdminEndpointExtensions.cs
@@ -1,4 +1,5 @@
 using WidgetDepot.ApiService.Features.Admin.Customers;
+using WidgetDepot.ApiService.Features.Admin.Orders;
 
 namespace WidgetDepot.ApiService.Features.Admin;
 
@@ -7,6 +8,7 @@ public static class AdminEndpointExtensions
     public static IEndpointRouteBuilder MapAdminEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapCustomerAdminEndpoints();
+        app.MapOrderAdminEndpoints();
 
         return app;
     }

--- a/src/WidgetDepot.ApiService/Features/Admin/Orders/GetAdminOrderByNumber/GetAdminOrderByNumberEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/Admin/Orders/GetAdminOrderByNumber/GetAdminOrderByNumberEndpoint.cs
@@ -1,0 +1,26 @@
+namespace WidgetDepot.ApiService.Features.Admin.Orders.GetAdminOrderByNumber;
+
+public static class GetAdminOrderByNumberEndpoint
+{
+    public static IEndpointRouteBuilder MapGetAdminOrderByNumber(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/admin/orders/{orderNumber:int}", async (
+            int orderNumber,
+            GetAdminOrderByNumberHandler handler,
+            CancellationToken cancellationToken) =>
+        {
+            var result = await handler.HandleAsync(orderNumber, cancellationToken);
+
+            return result switch
+            {
+                GetAdminOrderByNumberNotFound => Results.NotFound(),
+                GetAdminOrderByNumberResponse response => Results.Ok(response),
+                _ => Results.Problem(statusCode: 500)
+            };
+        })
+        .WithName("GetAdminOrderByNumber")
+        .RequireAuthorization("IsAdmin");
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Admin/Orders/GetAdminOrderByNumber/GetAdminOrderByNumberHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Admin/Orders/GetAdminOrderByNumber/GetAdminOrderByNumberHandler.cs
@@ -14,6 +14,8 @@ public record GetAdminOrderByNumberAddressResponse(
     string State,
     string ZipCode);
 
+public record GetAdminOrderByNumberCustomerResponse(string FirstName, string LastName, string Email);
+
 public record GetAdminOrderByNumberResponse(
     int Id,
     string Status,
@@ -24,7 +26,8 @@ public record GetAdminOrderByNumberResponse(
     GetAdminOrderByNumberAddressResponse? BillingAddress,
     decimal? ShippingEstimate,
     TransmissionStatus? TransmissionStatus,
-    DateTime? TransmissionStatusChangedAt);
+    DateTime? TransmissionStatusChangedAt,
+    GetAdminOrderByNumberCustomerResponse? Customer);
 
 public record GetAdminOrderByNumberNotFound;
 
@@ -40,6 +43,9 @@ public class GetAdminOrderByNumberHandler(AppDbContext db)
         if (order is null)
             return new GetAdminOrderByNumberNotFound();
 
+        var customer = await db.Customers
+            .FirstOrDefaultAsync(c => c.Id == order.CustomerId, cancellationToken);
+
         return new GetAdminOrderByNumberResponse(
             order.Id,
             order.Status.ToString(),
@@ -50,7 +56,8 @@ public class GetAdminOrderByNumberHandler(AppDbContext db)
             MapAddress(order.BillingAddress),
             order.ShippingEstimate,
             order.TransmissionStatus,
-            order.TransmissionStatusChangedAt);
+            order.TransmissionStatusChangedAt,
+            customer is null ? null : new GetAdminOrderByNumberCustomerResponse(customer.FirstName, customer.LastName, customer.Email));
     }
 
     private static GetAdminOrderByNumberAddressResponse? MapAddress(Address? address) =>

--- a/src/WidgetDepot.ApiService/Features/Admin/Orders/GetAdminOrderByNumber/GetAdminOrderByNumberHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Admin/Orders/GetAdminOrderByNumber/GetAdminOrderByNumberHandler.cs
@@ -1,0 +1,64 @@
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.Admin.Orders.GetAdminOrderByNumber;
+
+public record GetAdminOrderByNumberItemResponse(int WidgetId, string Sku, string Name, decimal Weight, decimal UnitCost, int Quantity);
+
+public record GetAdminOrderByNumberAddressResponse(
+    string RecipientName,
+    string StreetLine1,
+    string? StreetLine2,
+    string City,
+    string State,
+    string ZipCode);
+
+public record GetAdminOrderByNumberResponse(
+    int Id,
+    string Status,
+    DateTime CreatedAt,
+    DateTime? SubmittedAt,
+    IReadOnlyList<GetAdminOrderByNumberItemResponse> Items,
+    GetAdminOrderByNumberAddressResponse? ShippingAddress,
+    GetAdminOrderByNumberAddressResponse? BillingAddress,
+    decimal? ShippingEstimate,
+    TransmissionStatus? TransmissionStatus,
+    DateTime? TransmissionStatusChangedAt);
+
+public record GetAdminOrderByNumberNotFound;
+
+public class GetAdminOrderByNumberHandler(AppDbContext db)
+{
+    public async Task<object> HandleAsync(int orderNumber, CancellationToken cancellationToken)
+    {
+        var order = await db.Orders
+            .Include(o => o.Items)
+            .ThenInclude(i => i.Widget)
+            .FirstOrDefaultAsync(o => o.Id == orderNumber, cancellationToken);
+
+        if (order is null)
+            return new GetAdminOrderByNumberNotFound();
+
+        return new GetAdminOrderByNumberResponse(
+            order.Id,
+            order.Status.ToString(),
+            order.CreatedAt,
+            order.SubmittedAt,
+            [.. order.Items.Select(i => new GetAdminOrderByNumberItemResponse(i.WidgetId, i.Widget.Sku, i.Widget.Name, i.Widget.Weight, i.Widget.Price, i.Quantity))],
+            MapAddress(order.ShippingAddress),
+            MapAddress(order.BillingAddress),
+            order.ShippingEstimate,
+            order.TransmissionStatus,
+            order.TransmissionStatusChangedAt);
+    }
+
+    private static GetAdminOrderByNumberAddressResponse? MapAddress(Address? address) =>
+        address is null ? null : new GetAdminOrderByNumberAddressResponse(
+            address.RecipientName,
+            address.StreetLine1,
+            address.StreetLine2,
+            address.City,
+            address.State,
+            address.ZipCode);
+}

--- a/src/WidgetDepot.ApiService/Features/Admin/Orders/OrderAdminEndpointExtensions.cs
+++ b/src/WidgetDepot.ApiService/Features/Admin/Orders/OrderAdminEndpointExtensions.cs
@@ -1,0 +1,12 @@
+using WidgetDepot.ApiService.Features.Admin.Orders.GetAdminOrderByNumber;
+
+namespace WidgetDepot.ApiService.Features.Admin.Orders;
+
+public static class OrderAdminEndpointExtensions
+{
+    public static IEndpointRouteBuilder MapOrderAdminEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGetAdminOrderByNumber();
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/Orders/GetByOrderNumber/GetByOrderNumberHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/Orders/GetByOrderNumber/GetByOrderNumberHandler.cs
@@ -22,7 +22,9 @@ public record GetByOrderNumberResponse(
     IReadOnlyList<GetByOrderNumberItemResponse> Items,
     GetByOrderNumberAddressResponse? ShippingAddress,
     GetByOrderNumberAddressResponse? BillingAddress,
-    decimal? ShippingEstimate);
+    decimal? ShippingEstimate,
+    TransmissionStatus? TransmissionStatus,
+    DateTime? TransmissionStatusChangedAt);
 
 public record GetByOrderNumberNotFound;
 
@@ -46,7 +48,9 @@ public class GetByOrderNumberHandler(AppDbContext db)
             [.. order.Items.Select(i => new GetByOrderNumberItemResponse(i.WidgetId, i.Widget.Sku, i.Widget.Name, i.Widget.Weight, i.Widget.Price, i.Quantity))],
             MapAddress(order.ShippingAddress),
             MapAddress(order.BillingAddress),
-            order.ShippingEstimate);
+            order.ShippingEstimate,
+            order.TransmissionStatus,
+            order.TransmissionStatusChangedAt);
     }
 
     private static GetByOrderNumberAddressResponse? MapAddress(Address? address) =>

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -12,6 +12,7 @@ using WidgetDepot.ApiService.Features.Admin.Customers.GetCustomerProfile;
 using WidgetDepot.ApiService.Features.Admin.Customers.PromoteCustomer;
 using WidgetDepot.ApiService.Features.Admin.Customers.ResetCustomerPassword;
 using WidgetDepot.ApiService.Features.Admin.Customers.UpdateCustomerEmail;
+using WidgetDepot.ApiService.Features.Admin.Orders.GetAdminOrderByNumber;
 using WidgetDepot.ApiService.Features.Admin.Seed;
 using WidgetDepot.ApiService.Features.Orders;
 using WidgetDepot.ApiService.Features.Orders.CalculateShipping;
@@ -102,6 +103,7 @@ builder.Services.AddScoped<DemoteCustomerHandler>();
 builder.Services.AddScoped<PromoteCustomerHandler>();
 builder.Services.AddScoped<ResetCustomerPasswordHandler>();
 builder.Services.AddScoped<UpdateCustomerEmailHandler>();
+builder.Services.AddScoped<GetAdminOrderByNumberHandler>();
 builder.Services.AddHostedService<ExpireDraftOrdersJob>();
 builder.Services.AddHostedService<TransmitOrdersJob>();
 

--- a/src/WidgetDepot.Web/Components/Layout/NavMenu.razor
+++ b/src/WidgetDepot.Web/Components/Layout/NavMenu.razor
@@ -72,6 +72,11 @@
                     </NavLink>
                 </div>
                 <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="admin/orders">
+                        <span class="bi bi-search" aria-hidden="true"></span> Order Lookup
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
                     <NavLink class="nav-link" href="admin/catalog-import">
                         <span class="bi bi-upload" aria-hidden="true"></span> Catalog Upload
                     </NavLink>

--- a/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderDetailPage.razor
+++ b/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderDetailPage.razor
@@ -22,6 +22,16 @@ else if (loadFailed)
 }
 else if (order is not null)
 {
+    @if (customer is not null)
+    {
+        <div class="card mb-3">
+            <div class="card-header">Customer</div>
+            <div class="card-body">
+                <p class="mb-1">@customer.FullName</p>
+                <p class="mb-0">@customer.Email</p>
+            </div>
+        </div>
+    }
     <OrderDetailView Order="order" />
 }
 
@@ -30,6 +40,7 @@ else if (order is not null)
     public int OrderNumber { get; set; }
 
     private OrderDetail? order;
+    private AdminOrderCustomer? customer;
     private bool isLoading = true;
     private bool notFound;
     private bool loadFailed;
@@ -40,10 +51,11 @@ else if (order is not null)
 
         switch (result)
         {
-            case GetOrderDetailResult.Success success:
+            case GetAdminOrderDetailResult.Success success:
                 order = success.Order;
+                customer = success.Customer;
                 break;
-            case GetOrderDetailResult.NotFound:
+            case GetAdminOrderDetailResult.NotFound:
                 notFound = true;
                 break;
             default:

--- a/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderDetailPage.razor
+++ b/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderDetailPage.razor
@@ -1,12 +1,12 @@
-@page "/orders/{orderNumber:int}"
+@page "/admin/orders/{orderNumber:int}"
 @rendermode InteractiveServer
-@attribute [Authorize]
-@using Microsoft.AspNetCore.Authorization
 @using WidgetDepot.Web.Features.Orders.Detail
 @using WidgetDepot.Web.Features.Orders.Shared
-@inject DetailService DetailService
+@inject AdminOrderLookupService LookupService
 
 <PageTitle>Order #@OrderNumber</PageTitle>
+
+<a href="/admin/orders" class="btn btn-secondary mb-3">Back to Order Lookup</a>
 
 @if (isLoading)
 {
@@ -14,7 +14,7 @@
 }
 else if (notFound)
 {
-    <div class="alert alert-warning">Order not found.</div>
+    <div class="alert alert-warning">Order @OrderNumber not found.</div>
 }
 else if (loadFailed)
 {
@@ -36,7 +36,7 @@ else if (order is not null)
 
     protected override async Task OnInitializedAsync()
     {
-        var result = await DetailService.GetOrderDetailAsync(OrderNumber);
+        var result = await LookupService.GetOrderDetailAsync(OrderNumber);
 
         switch (result)
         {

--- a/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderLookupModels.cs
+++ b/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderLookupModels.cs
@@ -12,6 +12,8 @@ internal record GetAdminOrderByNumberAddressResponse(
     string State,
     string ZipCode);
 
+internal record GetAdminOrderByNumberCustomerResponse(string FirstName, string LastName, string Email);
+
 internal record GetAdminOrderByNumberResponse(
     int Id,
     string Status,
@@ -22,4 +24,14 @@ internal record GetAdminOrderByNumberResponse(
     GetAdminOrderByNumberAddressResponse? BillingAddress,
     decimal? ShippingEstimate,
     TransmissionStatus? TransmissionStatus,
-    DateTime? TransmissionStatusChangedAt);
+    DateTime? TransmissionStatusChangedAt,
+    GetAdminOrderByNumberCustomerResponse? Customer);
+
+public record AdminOrderCustomer(string FullName, string Email);
+
+public abstract record GetAdminOrderDetailResult
+{
+    public record Success(OrderDetail Order, AdminOrderCustomer? Customer) : GetAdminOrderDetailResult;
+    public record NotFound : GetAdminOrderDetailResult;
+    public record Failure : GetAdminOrderDetailResult;
+}

--- a/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderLookupModels.cs
+++ b/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderLookupModels.cs
@@ -1,0 +1,25 @@
+using WidgetDepot.Web.Features.Orders.Detail;
+
+namespace WidgetDepot.Web.Features.Admin.Orders;
+
+internal record GetAdminOrderByNumberItemResponse(int WidgetId, string Sku, string Name, decimal Weight, decimal UnitCost, int Quantity);
+
+internal record GetAdminOrderByNumberAddressResponse(
+    string RecipientName,
+    string StreetLine1,
+    string? StreetLine2,
+    string City,
+    string State,
+    string ZipCode);
+
+internal record GetAdminOrderByNumberResponse(
+    int Id,
+    string Status,
+    DateTime CreatedAt,
+    DateTime? SubmittedAt,
+    IReadOnlyList<GetAdminOrderByNumberItemResponse> Items,
+    GetAdminOrderByNumberAddressResponse? ShippingAddress,
+    GetAdminOrderByNumberAddressResponse? BillingAddress,
+    decimal? ShippingEstimate,
+    TransmissionStatus? TransmissionStatus,
+    DateTime? TransmissionStatusChangedAt);

--- a/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderLookupPage.razor
+++ b/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderLookupPage.razor
@@ -1,0 +1,33 @@
+@page "/admin/orders"
+@rendermode InteractiveServer
+@using WidgetDepot.Web.Features.Orders.Detail
+@inject NavigationManager NavigationManager
+
+<PageTitle>Order Lookup</PageTitle>
+
+<h1>Order Lookup</h1>
+
+<div class="row">
+    <div class="col-md-6">
+        <EditForm Model="form" OnValidSubmit="HandleSubmit">
+            <DataAnnotationsValidator />
+
+            <div class="mb-3">
+                <label class="form-label" for="orderNumber">Order Number</label>
+                <InputNumber id="orderNumber" class="form-control" @bind-Value="form.OrderNumber" />
+                <ValidationMessage For="() => form.OrderNumber" class="text-danger" />
+            </div>
+
+            <button type="submit" class="btn btn-primary">Look Up</button>
+        </EditForm>
+    </div>
+</div>
+
+@code {
+    private readonly LookupFormModel form = new();
+
+    private void HandleSubmit()
+    {
+        NavigationManager.NavigateTo($"/admin/orders/{form.OrderNumber}");
+    }
+}

--- a/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderLookupService.cs
+++ b/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderLookupService.cs
@@ -13,18 +13,18 @@ public class AdminOrderLookupService
         _httpClient = httpClient;
     }
 
-    public async Task<GetOrderDetailResult> GetOrderDetailAsync(int orderNumber, CancellationToken cancellationToken = default)
+    public async Task<GetAdminOrderDetailResult> GetOrderDetailAsync(int orderNumber, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.GetAsync($"/admin/orders/{orderNumber}", cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
-            return new GetOrderDetailResult.NotFound();
+            return new GetAdminOrderDetailResult.NotFound();
 
         if (response.StatusCode == HttpStatusCode.OK)
         {
             var dto = await response.Content.ReadFromJsonAsync<GetAdminOrderByNumberResponse>(cancellationToken);
             if (dto is null)
-                return new GetOrderDetailResult.Failure();
+                return new GetAdminOrderDetailResult.Failure();
 
             var order = new OrderDetail(
                 dto.Id,
@@ -38,10 +38,14 @@ public class AdminOrderLookupService
                 dto.TransmissionStatus,
                 dto.TransmissionStatusChangedAt);
 
-            return new GetOrderDetailResult.Success(order);
+            AdminOrderCustomer? customer = dto.Customer is null
+                ? null
+                : new AdminOrderCustomer($"{dto.Customer.FirstName} {dto.Customer.LastName}", dto.Customer.Email);
+
+            return new GetAdminOrderDetailResult.Success(order, customer);
         }
 
-        return new GetOrderDetailResult.Failure();
+        return new GetAdminOrderDetailResult.Failure();
     }
 
     private static OrderDetailAddress? MapAddress(GetAdminOrderByNumberAddressResponse? address) =>

--- a/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderLookupService.cs
+++ b/src/WidgetDepot.Web/Features/Admin/Orders/AdminOrderLookupService.cs
@@ -1,26 +1,28 @@
 using System.Net;
 
-namespace WidgetDepot.Web.Features.Orders.Detail;
+using WidgetDepot.Web.Features.Orders.Detail;
 
-public class DetailService
+namespace WidgetDepot.Web.Features.Admin.Orders;
+
+public class AdminOrderLookupService
 {
     private readonly HttpClient _httpClient;
 
-    public DetailService(HttpClient httpClient)
+    public AdminOrderLookupService(HttpClient httpClient)
     {
         _httpClient = httpClient;
     }
 
     public async Task<GetOrderDetailResult> GetOrderDetailAsync(int orderNumber, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.GetAsync($"/orders/{orderNumber}", cancellationToken);
+        var response = await _httpClient.GetAsync($"/admin/orders/{orderNumber}", cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
             return new GetOrderDetailResult.NotFound();
 
         if (response.StatusCode == HttpStatusCode.OK)
         {
-            var dto = await response.Content.ReadFromJsonAsync<GetByOrderNumberResponse>(cancellationToken);
+            var dto = await response.Content.ReadFromJsonAsync<GetAdminOrderByNumberResponse>(cancellationToken);
             if (dto is null)
                 return new GetOrderDetailResult.Failure();
 
@@ -42,7 +44,7 @@ public class DetailService
         return new GetOrderDetailResult.Failure();
     }
 
-    private static OrderDetailAddress? MapAddress(GetByOrderNumberAddressResponse? address) =>
+    private static OrderDetailAddress? MapAddress(GetAdminOrderByNumberAddressResponse? address) =>
         address is null ? null : new OrderDetailAddress(
             address.RecipientName,
             address.StreetLine1,

--- a/src/WidgetDepot.Web/Features/Orders/Detail/DetailModels.cs
+++ b/src/WidgetDepot.Web/Features/Orders/Detail/DetailModels.cs
@@ -2,6 +2,14 @@ using System.ComponentModel.DataAnnotations;
 
 namespace WidgetDepot.Web.Features.Orders.Detail;
 
+public enum TransmissionStatus
+{
+    Pending = 0,
+    Transmitted = 1,
+    Failed = 2,
+    Missing = 3
+}
+
 public record OrderDetailItem(int WidgetId, string Sku, string Name, decimal Weight, decimal UnitCost, int Quantity);
 
 public record OrderDetailAddress(
@@ -20,7 +28,9 @@ public record OrderDetail(
     IReadOnlyList<OrderDetailItem> Items,
     OrderDetailAddress? ShippingAddress,
     OrderDetailAddress? BillingAddress,
-    decimal? ShippingEstimate);
+    decimal? ShippingEstimate,
+    TransmissionStatus? TransmissionStatus,
+    DateTime? TransmissionStatusChangedAt);
 
 public abstract record GetOrderDetailResult
 {
@@ -54,4 +64,6 @@ internal record GetByOrderNumberResponse(
     IReadOnlyList<GetByOrderNumberItemResponse> Items,
     GetByOrderNumberAddressResponse? ShippingAddress,
     GetByOrderNumberAddressResponse? BillingAddress,
-    decimal? ShippingEstimate);
+    decimal? ShippingEstimate,
+    TransmissionStatus? TransmissionStatus,
+    DateTime? TransmissionStatusChangedAt);

--- a/src/WidgetDepot.Web/Features/Orders/History/HistoryModels.cs
+++ b/src/WidgetDepot.Web/Features/Orders/History/HistoryModels.cs
@@ -1,12 +1,6 @@
-namespace WidgetDepot.Web.Features.Orders.History;
+using WidgetDepot.Web.Features.Orders.Detail;
 
-public enum TransmissionStatus
-{
-    Pending = 0,
-    Transmitted = 1,
-    Failed = 2,
-    Missing = 3
-}
+namespace WidgetDepot.Web.Features.Orders.History;
 
 public record RecentOrderListItem(
     int Id,

--- a/src/WidgetDepot.Web/Features/Orders/History/HistoryPage.razor
+++ b/src/WidgetDepot.Web/Features/Orders/History/HistoryPage.razor
@@ -3,6 +3,7 @@
 @attribute [Authorize]
 @using Microsoft.AspNetCore.Authorization
 @using WidgetDepot.Web.Features.Orders.History
+@using WidgetDepot.Web.Features.Orders.Detail
 @inject HistoryService HistoryService
 
 <PageTitle>My Recent Orders</PageTitle>

--- a/src/WidgetDepot.Web/Features/Orders/History/HistoryService.cs
+++ b/src/WidgetDepot.Web/Features/Orders/History/HistoryService.cs
@@ -1,5 +1,7 @@
 using System.Net;
 
+using WidgetDepot.Web.Features.Orders.Detail;
+
 namespace WidgetDepot.Web.Features.Orders.History;
 
 public class HistoryService

--- a/src/WidgetDepot.Web/Features/Orders/Shared/OrderDetailView.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Shared/OrderDetailView.razor
@@ -1,0 +1,103 @@
+@using WidgetDepot.Web.Features.Orders.Detail
+
+<h1>Order #@Order.Id</h1>
+
+<dl class="row mb-4">
+    <dt class="col-sm-3">Status</dt>
+    <dd class="col-sm-9">@Order.Status</dd>
+    <dt class="col-sm-3">Created</dt>
+    <dd class="col-sm-9">@Order.CreatedAt.ToString("d")</dd>
+    @if (Order.SubmittedAt.HasValue)
+    {
+        <dt class="col-sm-3">Submitted</dt>
+        <dd class="col-sm-9">@Order.SubmittedAt.Value.ToString("d")</dd>
+    }
+    @if (Order.ShippingEstimate.HasValue)
+    {
+        <dt class="col-sm-3">Est. Shipping</dt>
+        <dd class="col-sm-9">@Order.ShippingEstimate.Value.ToString("C")</dd>
+    }
+    @if (Order.TransmissionStatus.HasValue)
+    {
+        <dt class="col-sm-3">ERP Status</dt>
+        <dd class="col-sm-9">
+            @Order.TransmissionStatus
+            @if (Order.TransmissionStatusChangedAt.HasValue)
+            {
+                <span class="text-muted ms-1">@Order.TransmissionStatusChangedAt.Value.ToString("g")</span>
+            }
+        </dd>
+    }
+</dl>
+
+<h2>Items</h2>
+@if (Order.Items.Count == 0)
+{
+    <p class="text-muted">No items on this order.</p>
+}
+else
+{
+    <table class="table table-sm table-hover">
+        <thead class="table-dark">
+            <tr>
+                <th>SKU</th>
+                <th>Name</th>
+                <th>Weight</th>
+                <th>Unit Cost</th>
+                <th>Qty</th>
+                <th>Subtotal</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var item in Order.Items)
+            {
+                <tr>
+                    <td>@item.Sku</td>
+                    <td>@item.Name</td>
+                    <td>@item.Weight.ToString("F2")</td>
+                    <td>@item.UnitCost.ToString("C")</td>
+                    <td>@item.Quantity</td>
+                    <td>@((item.UnitCost * item.Quantity).ToString("C"))</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+<div class="row mt-4">
+    @if (Order.ShippingAddress is not null)
+    {
+        <div class="col-md-6">
+            <h2>Shipping Address</h2>
+            <address>
+                @Order.ShippingAddress.RecipientName<br />
+                @Order.ShippingAddress.StreetLine1<br />
+                @if (!string.IsNullOrEmpty(Order.ShippingAddress.StreetLine2))
+                {
+                    @Order.ShippingAddress.StreetLine2<br />
+                }
+                @Order.ShippingAddress.City, @Order.ShippingAddress.State @Order.ShippingAddress.ZipCode
+            </address>
+        </div>
+    }
+    @if (Order.BillingAddress is not null)
+    {
+        <div class="col-md-6">
+            <h2>Billing Address</h2>
+            <address>
+                @Order.BillingAddress.RecipientName<br />
+                @Order.BillingAddress.StreetLine1<br />
+                @if (!string.IsNullOrEmpty(Order.BillingAddress.StreetLine2))
+                {
+                    @Order.BillingAddress.StreetLine2<br />
+                }
+                @Order.BillingAddress.City, @Order.BillingAddress.State @Order.BillingAddress.ZipCode
+            </address>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired]
+    public required OrderDetail Order { get; set; }
+}

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -11,6 +11,7 @@ using WidgetDepot.Web.Features.Accounts.Profile;
 using WidgetDepot.Web.Features.Accounts.Register;
 using WidgetDepot.Web.Features.Admin.CatalogImport;
 using WidgetDepot.Web.Features.Admin.Customers;
+using WidgetDepot.Web.Features.Admin.Orders;
 using WidgetDepot.Web.Features.Catalog;
 using WidgetDepot.Web.Features.Orders.Create;
 using WidgetDepot.Web.Features.Orders.Create.Step1;
@@ -99,6 +100,10 @@ builder.Services.AddHttpClient<HistoryService>(client =>
     .AddHttpMessageHandler<CookieForwardingHandler>();
 
 builder.Services.AddHttpClient<DetailService>(client =>
+    client.BaseAddress = new Uri("https+http://apiservice"))
+    .AddHttpMessageHandler<CookieForwardingHandler>();
+
+builder.Services.AddHttpClient<AdminOrderLookupService>(client =>
     client.BaseAddress = new Uri("https+http://apiservice"))
     .AddHttpMessageHandler<CookieForwardingHandler>();
 

--- a/tests/WidgetDepot.Tests/Features/Orders/History/HistoryServiceTests.cs
+++ b/tests/WidgetDepot.Tests/Features/Orders/History/HistoryServiceTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 
 using Shouldly;
 
+using WidgetDepot.Web.Features.Orders.Detail;
 using WidgetDepot.Web.Features.Orders.History;
 
 namespace WidgetDepot.Tests.Features.Orders.History;


### PR DESCRIPTION
## Summary

- Extracts order detail markup from `DetailPage.razor` into a shared `OrderDetailView.razor` component (used by both customer and admin pages)
- Adds nullable `TransmissionStatus` / `TransmissionStatusChangedAt` to `OrderDetail` model and extends `GET /orders/{orderNumber}` to include those fields
- Adds admin-scoped `GET /admin/orders/{orderNumber}` endpoint (no customer filter, requires `IsAdmin` policy)
- Adds admin order lookup page at `/admin/orders` (form) and `/admin/orders/{orderNumber}` (detail), with an "Order Lookup" link in the admin nav

## Test plan

- [x] Build succeeds (`dotnet build`)
- [x] All unit tests pass (`dotnet test`)
- [x] Admin can navigate to Order Lookup from admin nav
- [x] Submitting empty order number shows validation message
- [x] Submitting a valid order number navigates to detail page and shows full order info including ERP transmission status
- [x] Submitting an unknown order number shows "not found" message
- [x] Customer-facing order detail page still works and now shows ERP status when present

Closes #137