### PR TITLE
Admin: Catalog CSV Upload (#138)

### DIFF
--- a/tests/WidgetDepot.E2E/tests/catalog-import.spec.ts
+++ b/tests/WidgetDepot.E2E/tests/catalog-import.spec.ts
@@ -4,6 +4,16 @@ import { test, expect } from './fixtures';
 const data = (file: string) => path.resolve(__dirname, 'data', file);
 
 test.describe('Catalog import page', () => {
+  // AC-admin-nav: The catalog CSV upload page is accessible from the admin navigation
+  test('admin nav link navigates to the catalog import page', async ({ navBar, catalogImportPage }) => {
+    await catalogImportPage.goto();
+    await catalogImportPage.waitForReady();
+    await expect(navBar.catalogUploadLink).toBeVisible();
+    await navBar.catalogUploadLink.click();
+    await expect(catalogImportPage.page).toHaveURL(/\/admin\/catalog-import/);
+    await expect(catalogImportPage.heading).toBeVisible();
+  });
+
   // AC1: A warehouse staff member can navigate to the admin catalog import page
   test('can navigate to the catalog import page', async ({ catalogImportPage }) => {
     await catalogImportPage.goto();

--- a/tests/WidgetDepot.E2E/tests/pages/components/NavBarComponent.ts
+++ b/tests/WidgetDepot.E2E/tests/pages/components/NavBarComponent.ts
@@ -4,11 +4,13 @@ export class NavBarComponent {
   readonly page: Page;
   readonly emailDisplay: Locator;
   readonly signOutLink: Locator;
+  readonly catalogUploadLink: Locator;
 
   constructor(page: Page) {
-    this.page        = page;
-    this.emailDisplay = page.locator('.top-row span');
-    this.signOutLink  = page.getByRole('link', { name: 'Sign Out' });
+    this.page             = page;
+    this.emailDisplay     = page.locator('.top-row span');
+    this.signOutLink      = page.getByRole('link', { name: 'Sign Out' });
+    this.catalogUploadLink = page.getByRole('link', { name: 'Catalog Upload' });
   }
 
   async signOut() {


### PR DESCRIPTION
## Summary

- The `CatalogImportPage.razor` was already protected by `[Authorize(Policy = "IsAdmin")]` via `Features/Admin/_Imports.razor` (applies to all pages in the Admin folder tree)
- The "Catalog Upload" nav link was already present in `NavMenu.razor` inside the `AuthorizeView Policy="IsAdmin"` block
- Added an E2E test to `catalog-import.spec.ts` verifying the admin nav link navigates to the catalog import page
- Added `catalogUploadLink` locator to `NavBarComponent` to support the new test

## Test plan

- [x] `dotnet build` passes with 0 warnings/errors
- [x] `dotnet test` passes (321 passed, 1 skipped)
- [x] `npx playwright test --list` confirms new test is listed without TypeScript errors
- [x] Run E2E tests against a live app to verify the nav link and upload flow end-to-end

Closes #138