### PR TITLE
Refactor: Extract HTTP client registrations from Program.cs

### DIFF
--- a/src/WidgetDepot.Web/Infrastructure/HttpClientExtensions.cs
+++ b/src/WidgetDepot.Web/Infrastructure/HttpClientExtensions.cs
@@ -1,0 +1,47 @@
+using WidgetDepot.Web.Features.Accounts.ForcePasswordChange;
+using WidgetDepot.Web.Features.Accounts.Login;
+using WidgetDepot.Web.Features.Accounts.PasswordChange;
+using WidgetDepot.Web.Features.Accounts.Profile;
+using WidgetDepot.Web.Features.Accounts.Register;
+using WidgetDepot.Web.Features.Admin.CatalogImport;
+using WidgetDepot.Web.Features.Admin.Customers;
+using WidgetDepot.Web.Features.Admin.Orders;
+using WidgetDepot.Web.Features.Catalog;
+using WidgetDepot.Web.Features.Orders.Create.Step1;
+using WidgetDepot.Web.Features.Orders.Create.Step2;
+using WidgetDepot.Web.Features.Orders.Create.Step3;
+using WidgetDepot.Web.Features.Orders.Detail;
+using WidgetDepot.Web.Features.Orders.History;
+using WidgetDepot.Web.Features.Orders.List;
+using WidgetDepot.Web.Features.Orders.Submit;
+
+namespace WidgetDepot.Web.Infrastructure;
+
+internal static class HttpClientExtensions
+{
+    private const string ApiServiceBaseAddress = "https+http://apiservice";
+
+    public static IServiceCollection AddApiHttpClients(this IServiceCollection services)
+    {
+        services.AddHttpClient<CatalogService>(c => c.BaseAddress = new Uri(ApiServiceBaseAddress));
+        services.AddHttpClient<CatalogImportService>(c => c.BaseAddress = new Uri(ApiServiceBaseAddress));
+        services.AddHttpClient<RegisterService>(c => c.BaseAddress = new Uri(ApiServiceBaseAddress));
+        services.AddHttpClient<LoginService>(c => c.BaseAddress = new Uri(ApiServiceBaseAddress));
+
+        Action<HttpClient> withBase = c => c.BaseAddress = new Uri(ApiServiceBaseAddress);
+        services.AddHttpClient<CustomerListService>(withBase).AddHttpMessageHandler<CookieForwardingHandler>();
+        services.AddHttpClient<ProfileService>(withBase).AddHttpMessageHandler<CookieForwardingHandler>();
+        services.AddHttpClient<PasswordChangeService>(withBase).AddHttpMessageHandler<CookieForwardingHandler>();
+        services.AddHttpClient<ForcePasswordChangeService>(withBase).AddHttpMessageHandler<CookieForwardingHandler>();
+        services.AddHttpClient<Step1Service>(withBase).AddHttpMessageHandler<CookieForwardingHandler>();
+        services.AddHttpClient<Step2Service>(withBase).AddHttpMessageHandler<CookieForwardingHandler>();
+        services.AddHttpClient<Step3Service>(withBase).AddHttpMessageHandler<CookieForwardingHandler>();
+        services.AddHttpClient<ListService>(withBase).AddHttpMessageHandler<CookieForwardingHandler>();
+        services.AddHttpClient<Step4Service>(withBase).AddHttpMessageHandler<CookieForwardingHandler>();
+        services.AddHttpClient<HistoryService>(withBase).AddHttpMessageHandler<CookieForwardingHandler>();
+        services.AddHttpClient<DetailService>(withBase).AddHttpMessageHandler<CookieForwardingHandler>();
+        services.AddHttpClient<AdminOrderLookupService>(withBase).AddHttpMessageHandler<CookieForwardingHandler>();
+
+        return services;
+    }
+}

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -5,23 +5,8 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.DataProtection;
 
 using WidgetDepot.Web.Components;
-using WidgetDepot.Web.Features.Accounts.ForcePasswordChange;
-using WidgetDepot.Web.Features.Accounts.Login;
-using WidgetDepot.Web.Features.Accounts.PasswordChange;
-using WidgetDepot.Web.Features.Accounts.Profile;
-using WidgetDepot.Web.Features.Accounts.Register;
-using WidgetDepot.Web.Features.Admin.CatalogImport;
 using WidgetDepot.Web.Features.Admin.Customers;
-using WidgetDepot.Web.Features.Admin.Orders;
-using WidgetDepot.Web.Features.Catalog;
 using WidgetDepot.Web.Features.Orders.Create;
-using WidgetDepot.Web.Features.Orders.Create.Step1;
-using WidgetDepot.Web.Features.Orders.Create.Step2;
-using WidgetDepot.Web.Features.Orders.Create.Step3;
-using WidgetDepot.Web.Features.Orders.Detail;
-using WidgetDepot.Web.Features.Orders.History;
-using WidgetDepot.Web.Features.Orders.List;
-using WidgetDepot.Web.Features.Orders.Submit;
 using WidgetDepot.Web.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -51,66 +36,8 @@ builder.Services.AddTransient<CookieForwardingHandler>();
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
-builder.Services.AddHttpClient<CatalogService>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"));
-
-builder.Services.AddHttpClient<CatalogImportService>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"));
-
 builder.Services.Configure<PaginationOptions>(builder.Configuration.GetSection("Pagination"));
-builder.Services.AddHttpClient<CustomerListService>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"))
-    .AddHttpMessageHandler<CookieForwardingHandler>();
-
-builder.Services.AddHttpClient<RegisterService>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"));
-
-builder.Services.AddHttpClient<LoginService>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"));
-
-builder.Services.AddHttpClient<ProfileService>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"))
-    .AddHttpMessageHandler<CookieForwardingHandler>();
-
-builder.Services.AddHttpClient<PasswordChangeService>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"))
-    .AddHttpMessageHandler<CookieForwardingHandler>();
-
-builder.Services.AddHttpClient<ForcePasswordChangeService>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"))
-    .AddHttpMessageHandler<CookieForwardingHandler>();
-
-builder.Services.AddHttpClient<Step1Service>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"))
-    .AddHttpMessageHandler<CookieForwardingHandler>();
-
-builder.Services.AddHttpClient<Step2Service>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"))
-    .AddHttpMessageHandler<CookieForwardingHandler>();
-
-builder.Services.AddHttpClient<Step3Service>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"))
-    .AddHttpMessageHandler<CookieForwardingHandler>();
-
-builder.Services.AddHttpClient<ListService>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"))
-    .AddHttpMessageHandler<CookieForwardingHandler>();
-
-builder.Services.AddHttpClient<Step4Service>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"))
-    .AddHttpMessageHandler<CookieForwardingHandler>();
-
-builder.Services.AddHttpClient<HistoryService>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"))
-    .AddHttpMessageHandler<CookieForwardingHandler>();
-
-builder.Services.AddHttpClient<DetailService>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"))
-    .AddHttpMessageHandler<CookieForwardingHandler>();
-
-builder.Services.AddHttpClient<AdminOrderLookupService>(client =>
-    client.BaseAddress = new Uri("https+http://apiservice"))
-    .AddHttpMessageHandler<CookieForwardingHandler>();
+builder.Services.AddApiHttpClients();
 
 builder.Services.AddScoped<OrderWizardState>();
 


### PR DESCRIPTION
## Summary

- Moves 15 near-identical `AddHttpClient<T>` calls out of `Program.cs` into a new `HttpClientExtensions.AddApiHttpClients()` extension method in `src/WidgetDepot.Web/Infrastructure/`
- Reduces the HTTP client block in `Program.cs` to a single line
- Groups unauthenticated clients and cookie-forwarding clients clearly within the extension method

## Test plan

- [ ] `dotnet build` passes with no errors or warnings
- [ ] `dotnet test` passes
- [ ] `aspire run` — verify catalog page loads (unauthenticated client) and order/profile flows work (cookie-forwarding clients)
- [ ] `npm test --prefix tests/WidgetDepot.E2E` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)