### PR TITLE
Fix profile save crash: missing isAdmin and mustChangePassword params

### DIFF
--- a/src/WidgetDepot.Web/Features/Accounts/Profile/ProfilePage.razor
+++ b/src/WidgetDepot.Web/Features/Accounts/Profile/ProfilePage.razor
@@ -248,7 +248,9 @@
                 case UpdateProfileResult.Success success:
                     var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
                     var customerId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
-                    var url = $"/accounts/do-signin?customerId={Uri.EscapeDataString(customerId)}&email={Uri.EscapeDataString(success.Profile.Email)}&firstName={Uri.EscapeDataString(success.Profile.FirstName)}&returnUrl={Uri.EscapeDataString("/accounts/profile?saved=true")}";
+                    var isAdmin = authState.User.HasClaim("IsAdmin", "true");
+                    var mustChangePassword = authState.User.HasClaim("MustChangePassword", "true");
+                    var url = $"/accounts/do-signin?customerId={Uri.EscapeDataString(customerId)}&email={Uri.EscapeDataString(success.Profile.Email)}&firstName={Uri.EscapeDataString(success.Profile.FirstName)}&isAdmin={isAdmin}&mustChangePassword={mustChangePassword}&returnUrl={Uri.EscapeDataString("/accounts/profile?saved=true")}";
                     NavigationManager.NavigateTo(url, forceLoad: true);
                     break;
                 case UpdateProfileResult.DuplicateEmail:

--- a/tests/WidgetDepot.E2E/tests/fixtures/pages.ts
+++ b/tests/WidgetDepot.E2E/tests/fixtures/pages.ts
@@ -5,6 +5,7 @@ import { CustomerListPage } from '../pages/CustomerListPage';
 import { CustomerProfilePage } from '../pages/CustomerProfilePage';
 import { HomePage } from '../pages/HomePage';
 import { LoginPage } from '../pages/LoginPage';
+import { ProfilePage } from '../pages/ProfilePage';
 import { RegisterPage } from '../pages/RegisterPage';
 import { NavBarComponent } from '../pages/components/NavBarComponent';
 
@@ -15,6 +16,7 @@ export type PageFixtures = {
   customerProfilePage: CustomerProfilePage;
   homePage: HomePage;
   loginPage: LoginPage;
+  profilePage: ProfilePage;
   navBar: NavBarComponent;
   registerPage: RegisterPage;
 };
@@ -37,6 +39,9 @@ export const pagesTest = base.extend<PageFixtures>({
   },
   loginPage: async ({ page }, use) => {
     await use(new LoginPage(page));
+  },
+  profilePage: async ({ page }, use) => {
+    await use(new ProfilePage(page));
   },
   navBar: async ({ page }, use) => {
     await use(new NavBarComponent(page));

--- a/tests/WidgetDepot.E2E/tests/pages/ProfilePage.ts
+++ b/tests/WidgetDepot.E2E/tests/pages/ProfilePage.ts
@@ -1,0 +1,29 @@
+import { Page, Locator } from '@playwright/test';
+
+export class ProfilePage {
+  readonly page: Page;
+  readonly firstNameInput: Locator;
+  readonly submitButton: Locator;
+  readonly successAlert: Locator;
+  readonly errorAlert: Locator;
+
+  constructor(page: Page) {
+    this.page           = page;
+    this.firstNameInput = page.getByLabel('First Name');
+    this.submitButton   = page.getByRole('button', { name: 'Save' });
+    this.successAlert   = page.locator('.alert-success');
+    this.errorAlert     = page.locator('.alert-danger');
+  }
+
+  async goto() {
+    await this.page.goto('/accounts/profile');
+  }
+
+  async waitForReady() {
+    await this.page.waitForFunction(
+      () => !!(window as any).Blazor?._internal?.navigationManager,
+      { timeout: 30_000 }
+    );
+    await this.page.waitForLoadState('networkidle');
+  }
+}

--- a/tests/WidgetDepot.E2E/tests/profile.spec.ts
+++ b/tests/WidgetDepot.E2E/tests/profile.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from './fixtures';
+
+test.describe('User profile', () => {
+  // AC: Saving profile redirects back to profile page with a success confirmation
+  test('saving profile shows success confirmation', async ({ profilePage, page }) => {
+    await profilePage.goto();
+    await profilePage.waitForReady();
+
+    await profilePage.firstNameInput.clear();
+    await profilePage.firstNameInput.fill('Jane');
+    await profilePage.submitButton.click();
+
+    await page.waitForURL(/\/accounts\/profile/);
+    await expect(page).toHaveURL(/saved=true/);
+    await expect(profilePage.successAlert).toContainText('Your profile has been updated.');
+  });
+
+  // Regression: do-signin redirect after save was missing isAdmin and mustChangePassword params,
+  // causing a 400 and breaking the user's session.
+  test('authenticated session is preserved after saving profile', async ({ profilePage, page }) => {
+    await profilePage.goto();
+    await profilePage.waitForReady();
+
+    await profilePage.firstNameInput.clear();
+    await profilePage.firstNameInput.fill('Jane');
+    await profilePage.submitButton.click();
+
+    await page.waitForURL(/\/accounts\/profile/);
+
+    // Navigate to a protected route — if the session broke, we'd be redirected to login
+    await profilePage.goto();
+    await expect(page).not.toHaveURL(/\/accounts\/login/);
+  });
+});


### PR DESCRIPTION
## Summary

- The `/accounts/do-signin` redirect issued after a profile update was missing the required `isAdmin` and `mustChangePassword` query parameters, causing a `BadHttpRequestException` and breaking the user's session
- Fixed by reading those values from the current user's claims before building the redirect URL in `ProfilePage.razor`
- Added a `ProfilePage` E2E page object and spec to cover the save flow and guard against regressions

## Test plan

- [ ] Run the app, log in, navigate to `/accounts/profile`, update a field, and click Save — should redirect to `/accounts/profile?saved=true` with the success alert
- [ ] Verify session is still active after save (no redirect to login)
- [ ] Run `npm test --prefix tests/WidgetDepot.E2E -- --grep "User profile"` to exercise the new E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)