### PR TITLE
Add Milestone 5 story files: Problem Reporting

### DIFF
--- a/docs/milestone-05/01-problem-report-order-lookup.md
+++ b/docs/milestone-05/01-problem-report-order-lookup.md
@@ -1,7 +1,7 @@
 ---
-status: draft
+status: shared
 milestone: 5
-github_issue:
+github_issue: 156
 task_issues: []
 ---
 

--- a/docs/milestone-05/01-problem-report-order-lookup.md
+++ b/docs/milestone-05/01-problem-report-order-lookup.md
@@ -1,0 +1,51 @@
+---
+status: draft
+milestone: 5
+github_issue:
+task_issues: []
+---
+
+# Problem Report: Order Lookup
+
+## User Story
+
+> As a **customer**,
+> I need to look up one of my submitted orders by order number,
+> in order to begin filing a problem report against it.
+
+## Background
+
+This is the first step of the problem reporting wizard. The customer enters an order number, the system validates it, and displays the line items from that order. No problem report record is created yet — item selection happens in the next story.
+
+Only authenticated customers can access the wizard. The database contains only orders placed through the new system, so no special "old-system order" rejection logic is needed.
+
+## Scope
+
+**In scope:**
+- Order number entry form (authenticated customers only)
+- Validation that the order exists and belongs to the logged-in customer
+- Validation that the order is in a submitted state
+- Display of line items for the matched order (widget name, quantity ordered)
+
+**Out of scope:**
+- Item selection or issue type entry (story 2)
+- Creation of any problem report record
+- Any special rejection for "old-system" orders
+
+## Developer Notes
+
+- The wizard entry point should require authentication; redirect unauthenticated users to login.
+- A submitted order will always have at least one line item — no need to handle the empty items case.
+
+## Acceptance Criteria
+
+- [ ] Unauthenticated users are redirected to login when attempting to access the problem report wizard
+- [ ] An authenticated customer can enter an order number and submit the lookup form
+- [ ] If the order number matches a submitted order belonging to the customer, the line items are displayed (widget name, quantity ordered)
+- [ ] If the order number does not exist or belongs to a different customer, a clear error message is shown
+- [ ] If the order exists but is not in a submitted state, an appropriate error message is shown
+- [ ] Submitting an empty order number field shows a validation error
+
+## Refinement Notes
+
+The PRD restricts problem reports to orders placed through the new system. This is not a special validation rule — it is a natural consequence of the database only containing new-system orders. No rejection logic is required.

--- a/docs/milestone-05/02-problem-report-item-selection.md
+++ b/docs/milestone-05/02-problem-report-item-selection.md
@@ -1,0 +1,64 @@
+---
+status: draft
+milestone: 5
+github_issue:
+task_issues: []
+---
+
+# Problem Report: Item Selection and Submission
+
+## User Story
+
+> As a **customer**,
+> I need to select the affected items from my order, specify the issue type for each, and submit the problem report,
+> in order to notify warehouse staff of the exact nature of the problem.
+
+## Background
+
+This is the second step of the problem reporting wizard, following the order lookup (story 1). The customer selects one or more affected items, picks an issue type for each, optionally adds notes for the whole report, and submits. Submission saves the problem report to the database; the email notification is handled separately (story 3).
+
+Multiple problem reports can be filed against the same order.
+
+## Scope
+
+**In scope:**
+- Display of order line items with checkboxes for selection
+- Issue type selection per selected item (under-requested, over-requested, damaged)
+- Optional free-text notes field for the whole report (not per item)
+- Saving the completed problem report to the database on submission
+- Confirmation feedback after successful submission
+
+**Out of scope:**
+- Email notification (story 3)
+- Editing or deleting a submitted problem report
+- A "My Problem Reports" history view (deferred — to be discussed after milestone interviews)
+
+## Developer Notes
+
+The wizard uses a two sub-step flow within this screen:
+
+1. **Step A — Item selection:** All order line items are displayed with checkboxes. The customer checks the affected items and clicks "Next". At least one item must be selected to proceed.
+2. **Step B — Issue specification:** Only the selected items are shown, each with a required issue type dropdown (under-requested, over-requested, damaged). A single optional notes field for the whole report appears below the items. The customer clicks "Submit" to save the report.
+
+- Notes apply to the whole report, not to individual items.
+- Multiple reports against the same order are permitted.
+
+## Acceptance Criteria
+
+- [ ] Step A displays all order line items with checkboxes
+- [ ] Clicking "Next" on Step A with no items selected shows a validation error
+- [ ] Clicking "Next" with at least one item selected advances to Step B
+- [ ] Step B displays only the selected items, each with an issue type dropdown (under-requested, over-requested, damaged)
+- [ ] Step B includes a single optional free-text notes field for the whole report
+- [ ] Clicking "Submit" on Step B with any issue type unset shows a validation error
+- [ ] On valid submission, the problem report (order reference, affected items, issue types, notes) is saved to the database
+- [ ] After successful submission, the customer sees a confirmation message
+- [ ] Multiple problem reports can be submitted against the same order
+
+## Refinement Notes
+
+Notes are scoped to the whole report, not per item — confirmed with user. Multiple reports per order are explicitly permitted.
+
+The two sub-step flow (select items → specify issue types) was chosen over a single dynamic-reveal page to match the PRD's sequential framing and keep each step focused.
+
+"My Problem Reports" history view was raised during refinement and added as story 4.

--- a/docs/milestone-05/02-problem-report-item-selection.md
+++ b/docs/milestone-05/02-problem-report-item-selection.md
@@ -1,7 +1,7 @@
 ---
-status: draft
+status: shared
 milestone: 5
-github_issue:
+github_issue: 157
 task_issues: []
 ---
 

--- a/docs/milestone-05/03-problem-report-email.md
+++ b/docs/milestone-05/03-problem-report-email.md
@@ -1,7 +1,7 @@
 ---
-status: draft
+status: shared
 milestone: 5
-github_issue:
+github_issue: 158
 task_issues: []
 ---
 

--- a/docs/milestone-05/03-problem-report-email.md
+++ b/docs/milestone-05/03-problem-report-email.md
@@ -1,0 +1,58 @@
+---
+status: draft
+milestone: 5
+github_issue:
+task_issues: []
+---
+
+# Problem Report: Email Notification
+
+## User Story
+
+> As a **warehouse staff member**,
+> I need to receive an email when a customer files a problem report,
+> in order to act on the reported issue without manually checking the system.
+
+## Background
+
+When a customer submits a problem report, the system attempts to send an email to a configured warehouse staff mailbox. The report is always saved to the database regardless of email send outcome. An `EmailSent` flag on the report tracks whether the email was delivered successfully. Retry handling for failed sends is addressed in the "My Problem Reports" story.
+
+## Scope
+
+**In scope:**
+- Sending an email to the configured warehouse staff address on problem report submission
+- Email content: order number, affected items with issue types, and report notes
+- `EmailSent` flag on the problem report (set to `true` on successful send, `false` on failure)
+- Logging email send failures
+- Warehouse staff email address configurable in app settings
+
+**Out of scope:**
+- Customer-facing email confirmation (the wizard confirmation message covers this)
+- Retry UI for failed emails (handled in the "My Problem Reports" story)
+- Admin UI configuration of the recipient address
+
+## Developer Notes
+
+- This story includes setting up email integration for the first time in the project — there is no existing email infrastructure to build on.
+- Use the **MailKit** NuGet package for sending email.
+- For local development, spin up **Mailpit** as a containerized SMTP server via the Aspire community toolkit (`CommunityToolkit.Aspire.Hosting.Mailpit`). Mailpit captures outbound emails and exposes a web UI (port 8025) for inspection — no real emails are sent locally. In production, swap the connection string for a real SMTP provider.
+- Guidance on building Aspire hosting and client integrations:
+  - [Hosting integrations](https://aspire.dev/integrations/custom-integrations/hosting-integrations)
+  - [Client integrations](https://aspire.dev/integrations/custom-integrations/client-integrations)
+- The report must be saved before the email is attempted, so a send failure never causes data loss.
+- The `EmailSent` flag is the mechanism "My Problem Reports" will use to surface retry eligibility.
+- Recipient address lives in app configuration (e.g. `appsettings.json`), not in the database.
+
+## Acceptance Criteria
+
+- [ ] When a problem report is submitted, an email is sent to the configured warehouse staff address
+- [ ] The email contains the full report: order number, affected items with issue types, and notes
+- [ ] The warehouse staff email address is configurable in app settings
+- [ ] On successful send, `EmailSent` is set to `true` on the problem report record
+- [ ] If the email send fails, the report is still saved with `EmailSent` set to `false`
+- [ ] Email send failures are logged
+- [ ] The customer sees a confirmation message regardless of whether the email send succeeded
+
+## Refinement Notes
+
+Report persistence is decoupled from email delivery by design — confirmed with user. The `EmailSent` flag is the bridge to the retry flow that will live in "My Problem Reports." Recipient address is app config, not a database setting, so no admin UI is needed here.

--- a/docs/milestone-05/04-my-problem-reports.md
+++ b/docs/milestone-05/04-my-problem-reports.md
@@ -1,0 +1,52 @@
+---
+status: draft
+milestone: 5
+github_issue:
+task_issues: []
+---
+
+# My Problem Reports
+
+## User Story
+
+> As a **customer**,
+> I need to see my recent problem reports and retry failed email notifications,
+> in order to confirm my reports were received by warehouse staff.
+
+## Background
+
+After filing a problem report, a customer has no way to know if the warehouse staff email was delivered. This page surfaces that status and allows the customer to trigger a resend if the email failed. The `EmailSent` flag on the problem report (set in story 3) is the data source for email status.
+
+## Scope
+
+**In scope:**
+- A "My Problem Reports" page listing the customer's most recent 10 problem reports
+- Each row shows: order number, date order was submitted, date report was filed, email status
+- "Resend email" button for any report where `EmailSent = false`
+- Resend attempts to send to the same configured warehouse staff address
+- On successful resend, `EmailSent` is updated to `true` and the button is removed
+- On failed resend, an error message is shown and the button remains
+
+**Out of scope:**
+- Paginating beyond the most recent 10 reports
+- Automatic background retry (all retries are customer-initiated)
+- Editing or deleting a submitted problem report
+
+## Developer Notes
+
+- Resend uses the same email logic as the initial send in story 3.
+- The `EmailSent` flag is the sole source of truth for retry eligibility.
+
+## Acceptance Criteria
+
+- [ ] An authenticated customer can access the "My Problem Reports" page
+- [ ] The page lists the customer's most recent 10 problem reports; if fewer than 10 exist, all are shown
+- [ ] Each row displays: order number, date the order was submitted, date the report was filed, and email status (sent / not sent)
+- [ ] Reports where `EmailSent = false` display a "Resend email" button
+- [ ] Clicking "Resend email" triggers an email send to the configured warehouse staff address
+- [ ] On successful resend, `EmailSent` is set to `true` and the "Resend email" button is no longer shown
+- [ ] If the resend fails, an error message is shown and the "Resend email" button remains
+
+## Refinement Notes
+
+This story emerged from discussion about what happens when the initial email send fails (story 3). The customer-initiated retry model was chosen over a background retry job for simplicity. The 10-report limit was a deliberate choice — pagination deferred; the most common use case is checking the most recent report.

--- a/docs/milestone-05/04-my-problem-reports.md
+++ b/docs/milestone-05/04-my-problem-reports.md
@@ -1,7 +1,7 @@
 ---
-status: draft
+status: shared
 milestone: 5
-github_issue:
+github_issue: 159
 task_issues: []
 ---
 

--- a/docs/milestone-05/05-report-a-problem-link.md
+++ b/docs/milestone-05/05-report-a-problem-link.md
@@ -1,7 +1,7 @@
 ---
-status: draft
+status: shared
 milestone: 5
-github_issue:
+github_issue: 160
 task_issues: []
 ---
 

--- a/docs/milestone-05/05-report-a-problem-link.md
+++ b/docs/milestone-05/05-report-a-problem-link.md
@@ -1,0 +1,44 @@
+---
+status: draft
+milestone: 5
+github_issue:
+task_issues: []
+---
+
+# Report a Problem Link
+
+## User Story
+
+> As a **customer**,
+> I need a direct link from my order detail to the problem report wizard,
+> in order to report an issue without having to manually copy the order number.
+
+## Background
+
+Without this link, a customer must navigate to the problem report wizard separately and type in their order number. Adding a contextual link on the order detail page removes that friction and makes problem reporting more discoverable.
+
+## Scope
+
+**In scope:**
+- "Report a Problem" link on the order detail page for submitted orders
+- The link navigates to the problem report wizard with the order number pre-filled
+
+**Out of scope:**
+- The link on non-submitted orders (draft, expired, etc.)
+- The link on the "My Recent Orders" list page
+- Any changes to the wizard's validation logic (story 1 handles invalid order numbers)
+
+## Developer Notes
+
+- The order number should be passed as a URL parameter to the wizard; the wizard already validates ownership and status.
+- The link only renders when the order is in a submitted state.
+
+## Acceptance Criteria
+
+- [ ] The order detail page for a submitted order displays a "Report a Problem" link
+- [ ] Clicking the link navigates to the problem report wizard with the order number pre-filled
+- [ ] The link does not appear on non-submitted orders
+
+## Refinement Notes
+
+Link placement is order detail only — the "My Recent Orders" list was considered and deferred. Pre-filling via URL parameter keeps the wizard self-contained; story 1's validation remains the authoritative check on order eligibility.


### PR DESCRIPTION
## Summary

- Adds 5 refined user story files under `docs/milestone-05/` for the Problem Reporting milestone
- Stories cover the full problem reporting flow: order lookup, item selection wizard, email notification, "My Problem Reports" page, and a "Report a Problem" shortcut link from order detail
- All stories are `status: draft` — ready for review and promotion to `status: ready` before running `/share-milestone 5`

## Stories

| File | Title |
|---|---|
| `01-problem-report-order-lookup.md` | Problem Report: Order Lookup |
| `02-problem-report-item-selection.md` | Problem Report: Item Selection and Submission |
| `03-problem-report-email.md` | Problem Report: Email Notification |
| `04-my-problem-reports.md` | My Problem Reports |
| `05-report-a-problem-link.md` | Report a Problem Link |

## Test plan

- [x] Review each story file for accuracy against the PRD
- [x] Confirm scope boundaries and acceptance criteria are complete
- [x] Flip stories to `status: ready` when satisfied
- [x] Run `/share-milestone 5` to push stories to GitHub as issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)