### PR TITLE
Require Playwright E2E tests for acceptance criteria in Definition of Done

### DIFF
--- a/docs/standards/github-workflow.md
+++ b/docs/standards/github-workflow.md
@@ -8,10 +8,25 @@
 - Claude Code creates a branch named `issue-<number>-short-description` **before any Edit or Write tool call**.
 - Claude code runs `gh repo view --json nameWithOwner -q .nameWithOwner` to get the repo name, then pass it as a literal value to the next `gh` command — never use `$(...)` subshell substitution and never parse the repo name from `git remote get-url origin`
 - Claude Code reads the issue with `gh issue view 12`, understands the task, and starts working
+- Implementing the issue includes writing Playwright E2E tests that cover the acceptance criteria, following the `playwright-add-tests` skill (see [Definition of Done](#definition-of-done))
 - As work progresses, it (or you) can post progress updates as issue comments with `gh issue comment`
 - When done, Claude Code pushes the commits to the remote repo and then Claude Code opens a PR linked to the issue with `gh pr create`
 - You review, merge, and the issue closes automatically
 - Once the PR is merged, you say **"run post merge cleanup"** and Claude Code runs the [Post-merge cleanup](#post-merge-cleanup) sequence.
+
+---
+
+## Definition of Done
+
+An issue is not complete until all of the following are true:
+
+- The acceptance criteria are implemented.
+- Unit tests cover the new/changed behavior (see [testing](./testing.md)).
+- **Playwright E2E tests cover the issue's acceptance criteria.** For each acceptance criterion that is observable in the UI, there is a corresponding end-to-end test (or an assertion within one) under `tests/WidgetDepot.E2E`. When writing these tests you MUST follow the `playwright-add-tests` skill — do not write free-form specs.
+- All checks in [Before Creating a Commit](#before-creating-a-commit) pass.
+- Acceptance-criteria checkboxes are ticked off on the issue.
+
+If a criterion genuinely cannot be exercised end-to-end (e.g. a pure backend/data concern with no UI surface), note why in an issue comment instead of silently skipping it.
 
 ---
 


### PR DESCRIPTION
## What & why

When working on a GitHub issue, Claude Code reliably writes unit tests but not Playwright E2E tests. There was no explicit instruction driving either — unit-test behavior emerges from the model's nature plus the must-read standards docs. To get the same consistency for E2E coverage, this adds an explicit instruction to the doc that governs every issue.

## Changes

`docs/standards/github-workflow.md` (the must-read doc for every issue):

- **New "Definition of Done" section** making Playwright E2E coverage of the acceptance criteria an explicit completion requirement. It names the `playwright-add-tests` skill (the repo's authoritative POM + fixtures guide), points at `tests/WidgetDepot.E2E`, and includes an escape hatch for criteria with no UI surface.
- **Reinforcing bullet** in the Local Workflow narrative so the requirement is visible in the step-by-step flow, not only in the DoD section.

No code, settings, or skill files change. The existing pre-commit test-run gate is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)