### PR TITLE
Fix flaky profile E2E test caused by Blazor navigation interception

### DIFF
--- a/tests/WidgetDepot.E2E/tests/pages/ProfilePage.ts
+++ b/tests/WidgetDepot.E2E/tests/pages/ProfilePage.ts
@@ -16,7 +16,9 @@ export class ProfilePage {
   }
 
   async goto() {
-    await this.page.goto('/accounts/profile');
+    // waitUntil: 'commit' avoids net::ERR_ABORTED when Blazor's NavigationManager
+    // intercepts the request as a client-side route change before the load event fires.
+    await this.page.goto('/accounts/profile', { waitUntil: 'commit' });
   }
 
   async waitForReady() {


### PR DESCRIPTION
## Summary

- `ProfilePage.goto()` was using the default `waitUntil: 'load'`, which caused intermittent `net::ERR_ABORTED` errors
- After saving the profile, the page lands at `/accounts/profile?saved=true`; a subsequent `goto('/accounts/profile')` was intercepted by Blazor's NavigationManager as a client-side route change, aborting the network request before the `load` event could fire
- Changed to `waitUntil: 'commit'` so Playwright stops waiting as soon as HTTP response headers are committed — before Blazor can intervene; `waitForReady()` still handles full page readiness for tests that need it

## Test plan

- [ ] Run `npm test --prefix tests/WidgetDepot.E2E` and confirm `profile.spec.ts > authenticated session is preserved after saving profile` passes consistently
- [ ] Confirm `profile.spec.ts > saving profile shows success confirmation` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)