### PR TITLE
Add PR cleanup scripts for local git housekeeping

### DIFF
--- a/pr-cleanup.ps1
+++ b/pr-cleanup.ps1
@@ -1,0 +1,25 @@
+# Exit immediately on any error (PowerShell equivalent of set -e)
+$ErrorActionPreference = 'Stop'
+
+# Capture the current branch
+$currentBranch = git branch --show-current
+
+if ($currentBranch -eq 'main') {
+    Write-Host "Already on main. Skipping checkout and branch deletion."
+    git pull
+    git fetch --prune
+    exit 0
+}
+
+$branchToDelete = $currentBranch
+
+git checkout main
+git pull
+
+# Force-delete required: squash-merges leave the local branch looking
+# unmerged to git even though the work is already on main.
+git branch -D $branchToDelete
+
+git fetch --prune
+
+Write-Host "Done. Cleaned up branch: $branchToDelete"

--- a/pr-cleanup.sh
+++ b/pr-cleanup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Capture the current branch
+current_branch=$(git branch --show-current)
+
+if [[ "$current_branch" == "main" ]]; then
+    echo "Already on main. Skipping checkout and branch deletion."
+    git pull
+    git fetch --prune
+    exit 0
+fi
+
+# Store the branch name before switching away
+branch_to_delete="$current_branch"
+
+git checkout main
+git pull
+
+# Force-delete required: squash-merges leave the local branch looking
+# unmerged to git even though the work is already on main.
+git branch -D "$branch_to_delete"
+
+git fetch --prune
+
+echo "Done. Cleaned up branch: $branch_to_delete"


### PR DESCRIPTION
## Summary

- Adds `pr-cleanup.sh` (bash) and `pr-cleanup.ps1` (PowerShell) scripts for cleaning up local branches after a PR is merged
- Both scripts check out `main`, pull latest, force-delete the feature branch (`-D` is required because squash-merges leave the branch looking unmerged to git), then prune remote tracking refs
- Scripts are a no-op when already on `main`

## Test plan

- [x] Run `pr-cleanup.sh` while on a feature branch — confirm it switches to `main`, deletes the branch, and prunes
- [x] Run `pr-cleanup.ps1` while on a feature branch — confirm same behavior on Windows/PowerShell
- [x] Run either script while already on `main` — confirm it prints the skip message, pulls, and prunes without error