### PR TITLE
Add email notification on problem report submission (issue #158)

### DIFF
--- a/src/WidgetDepot.ApiService/Data/Migrations/20260620082229_AddEmailSentToProblemReport.Designer.cs
+++ b/src/WidgetDepot.ApiService/Data/Migrations/20260620082229_AddEmailSentToProblemReport.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WidgetDepot.ApiService.Data;
@@ -11,9 +12,11 @@ using WidgetDepot.ApiService.Data;
 namespace WidgetDepot.ApiService.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260620082229_AddEmailSentToProblemReport")]
+    partial class AddEmailSentToProblemReport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WidgetDepot.ApiService/Data/Migrations/20260620082229_AddEmailSentToProblemReport.cs
+++ b/src/WidgetDepot.ApiService/Data/Migrations/20260620082229_AddEmailSentToProblemReport.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WidgetDepot.ApiService.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmailSentToProblemReport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "EmailSent",
+                table: "ProblemReports",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmailSent",
+                table: "ProblemReports");
+        }
+    }
+}

--- a/src/WidgetDepot.ApiService/Data/ProblemReport.cs
+++ b/src/WidgetDepot.ApiService/Data/ProblemReport.cs
@@ -7,5 +7,6 @@ public class ProblemReport
     public Order Order { get; set; } = null!;
     public string? Notes { get; set; }
     public DateTime CreatedAt { get; set; }
+    public bool EmailSent { get; set; }
     public ICollection<ProblemReportItem> Items { get; set; } = [];
 }

--- a/src/WidgetDepot.ApiService/Features/ProblemReports/Email/EmailOptions.cs
+++ b/src/WidgetDepot.ApiService/Features/ProblemReports/Email/EmailOptions.cs
@@ -1,0 +1,9 @@
+namespace WidgetDepot.ApiService.Features.ProblemReports.Email;
+
+public class EmailOptions
+{
+    public string SmtpHost { get; set; } = "localhost";
+    public int SmtpPort { get; set; } = 1025;
+    public string FromAddress { get; set; } = "noreply@widgetdepot.local";
+    public string WarehouseStaffAddress { get; set; } = "";
+}

--- a/src/WidgetDepot.ApiService/Features/ProblemReports/Email/IProblemReportEmailSender.cs
+++ b/src/WidgetDepot.ApiService/Features/ProblemReports/Email/IProblemReportEmailSender.cs
@@ -1,0 +1,13 @@
+namespace WidgetDepot.ApiService.Features.ProblemReports.Email;
+
+public interface IProblemReportEmailSender
+{
+    Task<bool> SendAsync(ProblemReportEmailMessage message, CancellationToken cancellationToken);
+}
+
+public record ProblemReportEmailMessage(
+    int OrderId,
+    IReadOnlyList<ProblemReportEmailItem> Items,
+    string? Notes);
+
+public record ProblemReportEmailItem(string WidgetName, string IssueType);

--- a/src/WidgetDepot.ApiService/Features/ProblemReports/Email/MailKitProblemReportEmailSender.cs
+++ b/src/WidgetDepot.ApiService/Features/ProblemReports/Email/MailKitProblemReportEmailSender.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 using MailKit.Net.Smtp;
 
 using Microsoft.Extensions.Options;
@@ -29,7 +27,7 @@ public class MailKitProblemReportEmailSender : IProblemReportEmailSender
             email.From.Add(MailboxAddress.Parse(_options.FromAddress));
             email.To.Add(MailboxAddress.Parse(_options.WarehouseStaffAddress));
             email.Subject = $"Problem Report for Order #{message.OrderId}";
-            email.Body = new TextPart("plain") { Text = BuildEmailBody(message) };
+            email.Body = new TextPart("plain") { Text = ProblemReportEmailBodyBuilder.Build(message) };
 
             using var client = new SmtpClient();
             await client.ConnectAsync(_options.SmtpHost, _options.SmtpPort, MailKit.Security.SecureSocketOptions.None, cancellationToken);
@@ -43,23 +41,5 @@ public class MailKitProblemReportEmailSender : IProblemReportEmailSender
             _logger.LogError(ex, "Failed to send problem report email for order {OrderId}", message.OrderId);
             return false;
         }
-    }
-
-    private static string BuildEmailBody(ProblemReportEmailMessage message)
-    {
-        var sb = new StringBuilder();
-        sb.AppendLine($"Order: #{message.OrderId}");
-        sb.AppendLine();
-        sb.AppendLine("Reported Items:");
-        foreach (var item in message.Items)
-        {
-            sb.AppendLine($"  - {item.WidgetName}: {item.IssueType}");
-        }
-        if (!string.IsNullOrEmpty(message.Notes))
-        {
-            sb.AppendLine();
-            sb.AppendLine($"Notes: {message.Notes}");
-        }
-        return sb.ToString();
     }
 }

--- a/src/WidgetDepot.ApiService/Features/ProblemReports/Email/MailKitProblemReportEmailSender.cs
+++ b/src/WidgetDepot.ApiService/Features/ProblemReports/Email/MailKitProblemReportEmailSender.cs
@@ -1,0 +1,65 @@
+using System.Text;
+
+using MailKit.Net.Smtp;
+
+using Microsoft.Extensions.Options;
+
+using MimeKit;
+
+namespace WidgetDepot.ApiService.Features.ProblemReports.Email;
+
+public class MailKitProblemReportEmailSender : IProblemReportEmailSender
+{
+    private readonly EmailOptions _options;
+    private readonly ILogger<MailKitProblemReportEmailSender> _logger;
+
+    public MailKitProblemReportEmailSender(
+        IOptions<EmailOptions> options,
+        ILogger<MailKitProblemReportEmailSender> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<bool> SendAsync(ProblemReportEmailMessage message, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var email = new MimeMessage();
+            email.From.Add(MailboxAddress.Parse(_options.FromAddress));
+            email.To.Add(MailboxAddress.Parse(_options.WarehouseStaffAddress));
+            email.Subject = $"Problem Report for Order #{message.OrderId}";
+            email.Body = new TextPart("plain") { Text = BuildEmailBody(message) };
+
+            using var client = new SmtpClient();
+            await client.ConnectAsync(_options.SmtpHost, _options.SmtpPort, MailKit.Security.SecureSocketOptions.None, cancellationToken);
+            await client.SendAsync(email, cancellationToken);
+            await client.DisconnectAsync(true, cancellationToken);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send problem report email for order {OrderId}", message.OrderId);
+            return false;
+        }
+    }
+
+    private static string BuildEmailBody(ProblemReportEmailMessage message)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Order: #{message.OrderId}");
+        sb.AppendLine();
+        sb.AppendLine("Reported Items:");
+        foreach (var item in message.Items)
+        {
+            sb.AppendLine($"  - {item.WidgetName}: {item.IssueType}");
+        }
+        if (!string.IsNullOrEmpty(message.Notes))
+        {
+            sb.AppendLine();
+            sb.AppendLine($"Notes: {message.Notes}");
+        }
+        return sb.ToString();
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/ProblemReports/Email/ProblemReportEmailBodyBuilder.cs
+++ b/src/WidgetDepot.ApiService/Features/ProblemReports/Email/ProblemReportEmailBodyBuilder.cs
@@ -1,0 +1,24 @@
+using System.Text;
+
+namespace WidgetDepot.ApiService.Features.ProblemReports.Email;
+
+public static class ProblemReportEmailBodyBuilder
+{
+    public static string Build(ProblemReportEmailMessage message)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Order: #{message.OrderId}");
+        sb.AppendLine();
+        sb.AppendLine("Reported Items:");
+        foreach (var item in message.Items)
+        {
+            sb.AppendLine($"  - {item.WidgetName}: {item.IssueType}");
+        }
+        if (!string.IsNullOrEmpty(message.Notes))
+        {
+            sb.AppendLine();
+            sb.AppendLine($"Notes: {message.Notes}");
+        }
+        return sb.ToString();
+    }
+}

--- a/src/WidgetDepot.ApiService/Features/ProblemReports/SubmitProblemReport/SubmitProblemReportHandler.cs
+++ b/src/WidgetDepot.ApiService/Features/ProblemReports/SubmitProblemReport/SubmitProblemReportHandler.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 
 using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.ProblemReports.Email;
 using WidgetDepot.ApiService.Shared;
 
 namespace WidgetDepot.ApiService.Features.ProblemReports.SubmitProblemReport;
@@ -24,16 +25,18 @@ public record SubmitProblemReportInvalidItems;
 public class SubmitProblemReportHandler : IRequestHandler<SubmitProblemReportRequest, object>
 {
     private readonly AppDbContext _db;
+    private readonly IProblemReportEmailSender _emailSender;
 
-    public SubmitProblemReportHandler(AppDbContext db)
+    public SubmitProblemReportHandler(AppDbContext db, IProblemReportEmailSender emailSender)
     {
         _db = db;
+        _emailSender = emailSender;
     }
 
     public async Task<object> HandleAsync(SubmitProblemReportRequest request, CancellationToken cancellationToken)
     {
         var order = await _db.Orders
-            .Include(o => o.Items)
+            .Include(o => o.Items).ThenInclude(i => i.Widget)
             .FirstOrDefaultAsync(o => o.Id == request.OrderId && o.CustomerId == request.CustomerId, cancellationToken);
 
         if (order is null)
@@ -63,6 +66,25 @@ public class SubmitProblemReportHandler : IRequestHandler<SubmitProblemReportReq
         _db.ProblemReports.Add(report);
         await _db.SaveChangesAsync(cancellationToken);
 
+        var emailMessage = BuildEmailMessage(request, order);
+        var emailSent = await _emailSender.SendAsync(emailMessage, cancellationToken);
+
+        if (emailSent)
+        {
+            report.EmailSent = true;
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+
         return new SubmitProblemReportResponse(report.Id);
+    }
+
+    private static ProblemReportEmailMessage BuildEmailMessage(SubmitProblemReportRequest request, Order order)
+    {
+        var itemLookup = order.Items.ToDictionary(i => i.Id);
+        var emailItems = request.Items
+            .Select(i => new ProblemReportEmailItem(itemLookup[i.OrderItemId].Widget.Name, i.IssueType))
+            .ToList();
+
+        return new ProblemReportEmailMessage(request.OrderId, emailItems, request.Notes);
     }
 }

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -8,6 +8,7 @@ using WidgetDepot.ApiService.Features.Orders.CalculateShipping;
 using WidgetDepot.ApiService.Features.Orders.ExpireDraftOrders;
 using WidgetDepot.ApiService.Features.Orders.Submit;
 using WidgetDepot.ApiService.Features.Orders.TransmitOrders;
+using WidgetDepot.ApiService.Features.ProblemReports.Email;
 using WidgetDepot.ApiService.Shared;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -53,6 +54,9 @@ builder.Services.AddHttpClient<IShippingApiClient, AcmeShippingApiClient>(client
     client.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
 });
 builder.Services.AddRequestHandlers();
+
+builder.Services.Configure<EmailOptions>(builder.Configuration.GetSection("Email"));
+builder.Services.AddScoped<IProblemReportEmailSender, MailKitProblemReportEmailSender>();
 
 builder.Services.Configure<OrdersOptions>(builder.Configuration.GetSection("Orders"));
 builder.Services.AddScoped<IOrderFileWriter, OrderFileWriter>();

--- a/src/WidgetDepot.ApiService/WidgetDepot.ApiService.csproj
+++ b/src/WidgetDepot.ApiService/WidgetDepot.ApiService.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.2.4" />
     <PackageReference Include="FluentFTP" Version="54.2.0" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WidgetDepot.ApiService/appsettings.json
+++ b/src/WidgetDepot.ApiService/appsettings.json
@@ -18,5 +18,11 @@
     "Username": "",
     "Password": "",
     "RemoteDirectory": ""
+  },
+  "Email": {
+    "SmtpHost": "localhost",
+    "SmtpPort": 1025,
+    "FromAddress": "noreply@widgetdepot.local",
+    "WarehouseStaffAddress": "warehouse@widgetdepot.local"
   }
 }

--- a/src/WidgetDepot.AppHost/AppHost.cs
+++ b/src/WidgetDepot.AppHost/AppHost.cs
@@ -5,6 +5,8 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 var ftp = builder.AddFakeFtp();
 
+var mailpit = builder.AddMailpit();
+
 var postgres = builder.AddPostgres("postgres")
     .WithLifetime(ContainerLifetime.Persistent)
     .WithContainerName("postgres")
@@ -28,11 +30,14 @@ var apiService = builder.AddProject<Projects.WidgetDepot_ApiService>("apiservice
     .WithReference(fakeShippingApi)
     .WaitFor(fakeShippingApi)
     .WaitFor(ftp)
+    .WaitFor(mailpit)
     .WithEnvironment("FtpTransmission__Host", "127.0.0.1")
     .WithEnvironment("FtpTransmission__Port", FtpContainerExtensions.FtpHostPort.ToString())
     .WithEnvironment("FtpTransmission__Username", "devftp")
     .WithEnvironment("FtpTransmission__Password", "devftp")
-    .WithEnvironment("FtpTransmission__RemoteDirectory", "/home/devftp");
+    .WithEnvironment("FtpTransmission__RemoteDirectory", "/home/devftp")
+    .WithEnvironment("Email__SmtpHost", "127.0.0.1")
+    .WithEnvironment("Email__SmtpPort", MailpitContainerExtensions.SmtpHostPort.ToString());
 
 builder.AddProject<Projects.WidgetDepot_Web>("webfrontend")
     .WithExternalHttpEndpoints()

--- a/src/WidgetDepot.AppHost/MailpitContainerExtensions.cs
+++ b/src/WidgetDepot.AppHost/MailpitContainerExtensions.cs
@@ -1,0 +1,27 @@
+namespace WidgetDepot.AppHost;
+
+public static class MailpitContainerExtensions
+{
+    public const int SmtpHostPort = 1025;
+    public const int WebUiHostPort = 8025;
+
+    public static IResourceBuilder<ContainerResource> AddMailpit(this IDistributedApplicationBuilder builder)
+    {
+        return builder
+            .AddContainer("mailpit", "axllent/mailpit")
+            .WithLifetime(ContainerLifetime.Persistent)
+            .WithContainerName("mailpit")
+            .WithEndpoint(
+                port: SmtpHostPort,
+                targetPort: 1025,
+                scheme: "tcp",
+                name: "smtp",
+                isProxied: false)
+            .WithEndpoint(
+                port: WebUiHostPort,
+                targetPort: 8025,
+                scheme: "http",
+                name: "http",
+                isProxied: false);
+    }
+}

--- a/tests/WidgetDepot.Tests/Features/ProblemReports/Email/ProblemReportEmailBodyBuilderTests.cs
+++ b/tests/WidgetDepot.Tests/Features/ProblemReports/Email/ProblemReportEmailBodyBuilderTests.cs
@@ -1,0 +1,62 @@
+using Shouldly;
+
+using WidgetDepot.ApiService.Features.ProblemReports.Email;
+
+namespace WidgetDepot.Tests.Features.ProblemReports.Email;
+
+public class ProblemReportEmailBodyBuilderTests
+{
+    private static ProblemReportEmailMessage BuildMessage(
+        int orderId = 42,
+        IReadOnlyList<ProblemReportEmailItem>? items = null,
+        string? notes = null) =>
+        new(orderId, items ?? [], notes);
+
+    [Fact]
+    public void Build_IncludesOrderId_InBody()
+    {
+        var message = BuildMessage(orderId: 99);
+
+        var body = ProblemReportEmailBodyBuilder.Build(message);
+
+        body.ShouldContain("99");
+    }
+
+    [Fact]
+    public void Build_IncludesWidgetNameAndIssueType_ForEachItem()
+    {
+        var items = new List<ProblemReportEmailItem>
+        {
+            new("Sprocket", "Damaged"),
+            new("Cog", "UnderRequested")
+        };
+        var message = BuildMessage(items: items);
+
+        var body = ProblemReportEmailBodyBuilder.Build(message);
+
+        body.ShouldContain("Sprocket");
+        body.ShouldContain("Damaged");
+        body.ShouldContain("Cog");
+        body.ShouldContain("UnderRequested");
+    }
+
+    [Fact]
+    public void Build_IncludesNotes_WhenNotesPresent()
+    {
+        var message = BuildMessage(notes: "Arrived in poor condition");
+
+        var body = ProblemReportEmailBodyBuilder.Build(message);
+
+        body.ShouldContain("Arrived in poor condition");
+    }
+
+    [Fact]
+    public void Build_ExcludesNotesSection_WhenNotesIsNull()
+    {
+        var message = BuildMessage(notes: null);
+
+        var body = ProblemReportEmailBodyBuilder.Build(message);
+
+        body.ShouldNotContain("Notes:");
+    }
+}

--- a/tests/WidgetDepot.Tests/Features/ProblemReports/SubmitProblemReport/SubmitProblemReportHandlerTests.cs
+++ b/tests/WidgetDepot.Tests/Features/ProblemReports/SubmitProblemReport/SubmitProblemReportHandlerTests.cs
@@ -1,8 +1,11 @@
 using Microsoft.EntityFrameworkCore;
 
+using Moq;
+
 using Shouldly;
 
 using WidgetDepot.ApiService.Data;
+using WidgetDepot.ApiService.Features.ProblemReports.Email;
 using WidgetDepot.ApiService.Features.ProblemReports.SubmitProblemReport;
 
 namespace WidgetDepot.Tests.Features.ProblemReports.SubmitProblemReport;
@@ -15,6 +18,14 @@ public class SubmitProblemReportHandlerTests
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
         return new AppDbContext(options);
+    }
+
+    private static Mock<IProblemReportEmailSender> CreateEmailSender(bool returns = true)
+    {
+        var mock = new Mock<IProblemReportEmailSender>();
+        mock.Setup(s => s.SendAsync(It.IsAny<ProblemReportEmailMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(returns);
+        return mock;
     }
 
     private static async Task<(Order Order, OrderItem Item)> SeedSubmittedOrderWithItemAsync(
@@ -61,7 +72,7 @@ public class SubmitProblemReportHandlerTests
     public async Task HandleAsync_OrderNotFound_ReturnsOrderNotFound()
     {
         using var db = CreateDb();
-        var handler = new SubmitProblemReportHandler(db);
+        var handler = new SubmitProblemReportHandler(db, CreateEmailSender().Object);
 
         var result = await handler.HandleAsync(BuildRequest(999, 1), TestContext.Current.CancellationToken);
 
@@ -73,7 +84,7 @@ public class SubmitProblemReportHandlerTests
     {
         using var db = CreateDb();
         var (order, _) = await SeedSubmittedOrderWithItemAsync(db, customerId: 1);
-        var handler = new SubmitProblemReportHandler(db);
+        var handler = new SubmitProblemReportHandler(db, CreateEmailSender().Object);
 
         var result = await handler.HandleAsync(BuildRequest(order.Id, 2), TestContext.Current.CancellationToken);
 
@@ -87,7 +98,7 @@ public class SubmitProblemReportHandlerTests
         var order = new Order { CustomerId = 1, Status = OrderStatus.Draft, CreatedAt = DateTime.UtcNow };
         db.Orders.Add(order);
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
-        var handler = new SubmitProblemReportHandler(db);
+        var handler = new SubmitProblemReportHandler(db, CreateEmailSender().Object);
 
         var result = await handler.HandleAsync(BuildRequest(order.Id, 1), TestContext.Current.CancellationToken);
 
@@ -99,7 +110,7 @@ public class SubmitProblemReportHandlerTests
     {
         using var db = CreateDb();
         var (order, _) = await SeedSubmittedOrderWithItemAsync(db, customerId: 1);
-        var handler = new SubmitProblemReportHandler(db);
+        var handler = new SubmitProblemReportHandler(db, CreateEmailSender().Object);
         var items = new List<SubmitProblemReportItemRequest>
         {
             new(99999, "Damaged")
@@ -115,7 +126,7 @@ public class SubmitProblemReportHandlerTests
     {
         using var db = CreateDb();
         var (order, item) = await SeedSubmittedOrderWithItemAsync(db, customerId: 1);
-        var handler = new SubmitProblemReportHandler(db);
+        var handler = new SubmitProblemReportHandler(db, CreateEmailSender().Object);
         var items = new List<SubmitProblemReportItemRequest>
         {
             new(item.Id, "Damaged")
@@ -139,7 +150,7 @@ public class SubmitProblemReportHandlerTests
     {
         using var db = CreateDb();
         var (order, item) = await SeedSubmittedOrderWithItemAsync(db, customerId: 1);
-        var handler = new SubmitProblemReportHandler(db);
+        var handler = new SubmitProblemReportHandler(db, CreateEmailSender().Object);
         var items = new List<SubmitProblemReportItemRequest> { new(item.Id, "Damaged") };
 
         await handler.HandleAsync(BuildRequest(order.Id, 1, items), TestContext.Current.CancellationToken);
@@ -154,12 +165,75 @@ public class SubmitProblemReportHandlerTests
     {
         using var db = CreateDb();
         var (order, item) = await SeedSubmittedOrderWithItemAsync(db, customerId: 1);
-        var handler = new SubmitProblemReportHandler(db);
+        var handler = new SubmitProblemReportHandler(db, CreateEmailSender().Object);
         var items = new List<SubmitProblemReportItemRequest> { new(item.Id, "UnderRequested") };
 
         await handler.HandleAsync(BuildRequest(order.Id, 1, items), TestContext.Current.CancellationToken);
 
         var saved = await db.ProblemReports.FirstAsync(TestContext.Current.CancellationToken);
         saved.CreatedAt.ShouldNotBe(default);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ValidRequest_SendsEmailWithOrderDetails()
+    {
+        using var db = CreateDb();
+        var (order, item) = await SeedSubmittedOrderWithItemAsync(db, customerId: 1);
+        var emailSender = CreateEmailSender();
+        var handler = new SubmitProblemReportHandler(db, emailSender.Object);
+        var items = new List<SubmitProblemReportItemRequest> { new(item.Id, "Damaged") };
+
+        await handler.HandleAsync(BuildRequest(order.Id, 1, items, "Broken on arrival"), TestContext.Current.CancellationToken);
+
+        emailSender.Verify(s => s.SendAsync(
+            It.Is<ProblemReportEmailMessage>(m =>
+                m.OrderId == order.Id &&
+                m.Notes == "Broken on arrival" &&
+                m.Items.Count == 1 &&
+                m.Items[0].IssueType == "Damaged"),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_EmailSendSucceeds_EmailSentSetToTrue()
+    {
+        using var db = CreateDb();
+        var (order, item) = await SeedSubmittedOrderWithItemAsync(db, customerId: 1);
+        var handler = new SubmitProblemReportHandler(db, CreateEmailSender(returns: true).Object);
+        var items = new List<SubmitProblemReportItemRequest> { new(item.Id, "Damaged") };
+
+        await handler.HandleAsync(BuildRequest(order.Id, 1, items), TestContext.Current.CancellationToken);
+
+        var saved = await db.ProblemReports.FirstAsync(TestContext.Current.CancellationToken);
+        saved.EmailSent.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task HandleAsync_EmailSendFails_ReportSavedWithEmailSentFalse()
+    {
+        using var db = CreateDb();
+        var (order, item) = await SeedSubmittedOrderWithItemAsync(db, customerId: 1);
+        var handler = new SubmitProblemReportHandler(db, CreateEmailSender(returns: false).Object);
+        var items = new List<SubmitProblemReportItemRequest> { new(item.Id, "Damaged") };
+
+        var result = await handler.HandleAsync(BuildRequest(order.Id, 1, items), TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitProblemReportResponse>();
+        var saved = await db.ProblemReports.FirstAsync(TestContext.Current.CancellationToken);
+        saved.EmailSent.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAsync_EmailSendFails_StillReturnsSuccessResponse()
+    {
+        using var db = CreateDb();
+        var (order, item) = await SeedSubmittedOrderWithItemAsync(db, customerId: 1);
+        var handler = new SubmitProblemReportHandler(db, CreateEmailSender(returns: false).Object);
+        var items = new List<SubmitProblemReportItemRequest> { new(item.Id, "Damaged") };
+
+        var result = await handler.HandleAsync(BuildRequest(order.Id, 1, items), TestContext.Current.CancellationToken);
+
+        result.ShouldBeOfType<SubmitProblemReportResponse>();
     }
 }


### PR DESCRIPTION
## Summary

- Sends an email to the configured warehouse staff address when a customer submits a problem report
- Report is always saved first; email failure sets `EmailSent=false` and logs the error — no data loss
- Mailpit container added to Aspire AppHost for local dev inspection (SMTP :1025, web UI :8025)

## Changes

- `ProblemReport` entity: added `EmailSent bool` column + migration
- New `Features/ProblemReports/Email/` slice: `EmailOptions`, `IProblemReportEmailSender`, `MailKitProblemReportEmailSender`
- `SubmitProblemReportHandler`: injects `IProblemReportEmailSender`, sends after save, updates `EmailSent` flag
- `appsettings.json`: added `Email` section with SMTP and recipient defaults
- `AppHost`: added `MailpitContainerExtensions` (mirrors `FtpContainerExtensions`) and wires SMTP env vars
- 4 new unit tests for email send success/failure behavior; existing tests updated for new constructor

## Test plan

- [x] `dotnet test` — 350 passing, 1 skipped
- [x] `CI=true npm test --prefix tests/WidgetDepot.E2E` — 58 passing
- [x] Run locally with `aspire run`, submit a problem report, verify email appears in Mailpit at http://localhost:8025

Closes #158