### PR TITLE
Add Report a Problem link to order detail page

### DIFF
--- a/src/WidgetDepot.Web/Features/Orders/Shared/OrderDetailView.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Shared/OrderDetailView.razor
@@ -30,13 +30,6 @@
     }
 </dl>
 
-@if (Order.Status == "Submitted")
-{
-    <div class="mb-4">
-        <a href="/problem-reports/create/@Order.Id" class="btn btn-outline-warning">Report a Problem</a>
-    </div>
-}
-
 <h2>Items</h2>
 @if (Order.Items.Count == 0)
 {
@@ -103,6 +96,13 @@ else
         </div>
     }
 </div>
+
+@if (Order.Status == "Submitted")
+{
+    <div class="mt-4">
+        <a href="/problem-reports/create/@Order.Id" class="btn btn-sm btn-warning">Report a Problem</a>
+    </div>
+}
 
 @code {
     [Parameter, EditorRequired]

--- a/src/WidgetDepot.Web/Features/Orders/Shared/OrderDetailView.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Shared/OrderDetailView.razor
@@ -64,6 +64,13 @@ else
     </table>
 }
 
+@if (Order.Status == "Submitted")
+{
+    <div class="mt-4">
+        <a href="/problem-reports/create/@Order.Id" class="btn btn-sm btn-warning">Report a Problem</a>
+    </div>
+}
+
 <div class="row mt-4">
     @if (Order.ShippingAddress is not null)
     {
@@ -96,13 +103,6 @@ else
         </div>
     }
 </div>
-
-@if (Order.Status == "Submitted")
-{
-    <div class="mt-4">
-        <a href="/problem-reports/create/@Order.Id" class="btn btn-sm btn-warning">Report a Problem</a>
-    </div>
-}
 
 @code {
     [Parameter, EditorRequired]

--- a/src/WidgetDepot.Web/Features/Orders/Shared/OrderDetailView.razor
+++ b/src/WidgetDepot.Web/Features/Orders/Shared/OrderDetailView.razor
@@ -30,6 +30,13 @@
     }
 </dl>
 
+@if (Order.Status == "Submitted")
+{
+    <div class="mb-4">
+        <a href="/problem-reports/create/@Order.Id" class="btn btn-outline-warning">Report a Problem</a>
+    </div>
+}
+
 <h2>Items</h2>
 @if (Order.Items.Count == 0)
 {

--- a/tests/WidgetDepot.E2E/tests/fixtures/pages.ts
+++ b/tests/WidgetDepot.E2E/tests/fixtures/pages.ts
@@ -1,5 +1,6 @@
 import { test as base } from '@playwright/test';
 import { CatalogImportPage } from '../pages/CatalogImportPage';
+import { OrderDetailPage } from '../pages/OrderDetailPage';
 import { CatalogPage } from '../pages/CatalogPage';
 import { CustomerListPage } from '../pages/CustomerListPage';
 import { CustomerProfilePage } from '../pages/CustomerProfilePage';
@@ -14,6 +15,7 @@ import { NavBarComponent } from '../pages/components/NavBarComponent';
 
 export type PageFixtures = {
   catalogImportPage: CatalogImportPage;
+  orderDetailPage: OrderDetailPage;
   catalogPage: CatalogPage;
   customerListPage: CustomerListPage;
   customerProfilePage: CustomerProfilePage;
@@ -30,6 +32,9 @@ export type PageFixtures = {
 export const pagesTest = base.extend<PageFixtures>({
   catalogImportPage: async ({ page }, use) => {
     await use(new CatalogImportPage(page));
+  },
+  orderDetailPage: async ({ page }, use) => {
+    await use(new OrderDetailPage(page));
   },
   catalogPage: async ({ page }, use) => {
     await use(new CatalogPage(page));

--- a/tests/WidgetDepot.E2E/tests/order-detail.spec.ts
+++ b/tests/WidgetDepot.E2E/tests/order-detail.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from './fixtures';
+
+test.describe('Order detail — Report a Problem link', () => {
+  // AC: The order detail page for a submitted order displays a "Report a Problem" link
+  test('shows Report a Problem link for submitted orders', async ({ orderDetailPage }) => {
+    test.skip(!process.env.E2E_SUBMITTED_ORDER_NUMBER, 'E2E_SUBMITTED_ORDER_NUMBER not set');
+    const orderNumber = parseInt(process.env.E2E_SUBMITTED_ORDER_NUMBER!);
+
+    await orderDetailPage.goto(orderNumber);
+    await orderDetailPage.waitForReady();
+
+    await expect(orderDetailPage.reportProblemLink).toBeVisible();
+  });
+
+  // AC: Clicking the link navigates to the problem report wizard with the order number pre-filled
+  test('Report a Problem link navigates to wizard with order number pre-filled', async ({ orderDetailPage, page }) => {
+    test.skip(!process.env.E2E_SUBMITTED_ORDER_NUMBER, 'E2E_SUBMITTED_ORDER_NUMBER not set');
+    const orderNumber = parseInt(process.env.E2E_SUBMITTED_ORDER_NUMBER!);
+
+    await orderDetailPage.goto(orderNumber);
+    await orderDetailPage.waitForReady();
+    await orderDetailPage.reportProblemLink.click();
+
+    await expect(page).toHaveURL(new RegExp(`/problem-reports/create/${orderNumber}`));
+  });
+
+  // AC: The link does not appear on non-submitted orders
+  test('does not show Report a Problem link for non-submitted orders', async ({ orderDetailPage }) => {
+    test.skip(!process.env.E2E_NONSUBMITTED_ORDER_NUMBER, 'E2E_NONSUBMITTED_ORDER_NUMBER not set');
+    const orderNumber = parseInt(process.env.E2E_NONSUBMITTED_ORDER_NUMBER!);
+
+    await orderDetailPage.goto(orderNumber);
+    await orderDetailPage.waitForReady();
+
+    await expect(orderDetailPage.reportProblemLink).not.toBeVisible();
+  });
+});

--- a/tests/WidgetDepot.E2E/tests/pages/OrderDetailPage.ts
+++ b/tests/WidgetDepot.E2E/tests/pages/OrderDetailPage.ts
@@ -1,0 +1,19 @@
+import { Page, Locator } from '@playwright/test';
+
+export class OrderDetailPage {
+  readonly page: Page;
+  readonly reportProblemLink: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.reportProblemLink = page.getByRole('link', { name: 'Report a Problem' });
+  }
+
+  async goto(orderNumber: number) {
+    await this.page.goto(`/orders/${orderNumber}`);
+  }
+
+  async waitForReady() {
+    await this.page.waitForLoadState('networkidle');
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a "Report a Problem" link to the order detail page that renders only when the order status is `Submitted`
- The link navigates to `/problem-reports/create/{orderId}`, pre-filling the order number in the wizard via URL parameter
- No changes to wizard validation logic — the wizard remains the authoritative check on order eligibility

## Test plan

- [ ] Build passes (`dotnet build`)
- [ ] Unit tests pass (`dotnet test --no-build`)
- [ ] `OrderDetailPage` page object and `order-detail.spec.ts` E2E tests added covering all three ACs
- [ ] Set `E2E_SUBMITTED_ORDER_NUMBER` and `E2E_NONSUBMITTED_ORDER_NUMBER` env vars to run the data-dependent E2E tests against a live instance

Closes #160