### PR TITLE
Fix flaky Resend email E2E test by seeding test data in beforeEach

### DIFF
--- a/src/WidgetDepot.ApiService/Features/ProblemReports/CreateTestProblemReport/CreateTestProblemReportEndpoint.cs
+++ b/src/WidgetDepot.ApiService/Features/ProblemReports/CreateTestProblemReport/CreateTestProblemReportEndpoint.cs
@@ -1,0 +1,52 @@
+using System.Security.Claims;
+
+using Microsoft.EntityFrameworkCore;
+
+using WidgetDepot.ApiService.Data;
+
+namespace WidgetDepot.ApiService.Features.ProblemReports.CreateTestProblemReport;
+
+internal record CreateTestProblemReportBody(int OrderId);
+
+public static class CreateTestProblemReportEndpoint
+{
+    public static IEndpointRouteBuilder MapCreateTestProblemReport(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/test/problem-reports", async (
+            CreateTestProblemReportBody body,
+            ClaimsPrincipal user,
+            AppDbContext db,
+            CancellationToken cancellationToken) =>
+        {
+            if (!user.TryGetCustomerId(out var customerId))
+                return Results.Unauthorized();
+
+            var order = await db.Orders
+                .Include(o => o.Items)
+                .FirstOrDefaultAsync(o => o.Id == body.OrderId && o.CustomerId == customerId, cancellationToken);
+
+            if (order is null)
+                return Results.NotFound();
+
+            var firstItem = order.Items.FirstOrDefault();
+            if (firstItem is null)
+                return Results.UnprocessableEntity();
+
+            var report = new ProblemReport
+            {
+                OrderId = body.OrderId,
+                CreatedAt = DateTime.UtcNow,
+                EmailSent = false,
+                Items = [new ProblemReportItem { OrderItemId = firstItem.Id, IssueType = IssueType.Damaged }]
+            };
+
+            db.ProblemReports.Add(report);
+            await db.SaveChangesAsync(cancellationToken);
+
+            return Results.Ok(new { problemReportId = report.Id });
+        })
+        .RequireAuthorization();
+
+        return app;
+    }
+}

--- a/src/WidgetDepot.ApiService/Program.cs
+++ b/src/WidgetDepot.ApiService/Program.cs
@@ -8,6 +8,7 @@ using WidgetDepot.ApiService.Features.Orders.CalculateShipping;
 using WidgetDepot.ApiService.Features.Orders.ExpireDraftOrders;
 using WidgetDepot.ApiService.Features.Orders.Submit;
 using WidgetDepot.ApiService.Features.Orders.TransmitOrders;
+using WidgetDepot.ApiService.Features.ProblemReports.CreateTestProblemReport;
 using WidgetDepot.ApiService.Features.ProblemReports.Email;
 using WidgetDepot.ApiService.Shared;
 
@@ -88,6 +89,7 @@ app.UseAuthorization();
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
+    app.MapCreateTestProblemReport();
 }
 
 app.MapGet("/", () => "API service is running.");

--- a/src/WidgetDepot.Web/Program.cs
+++ b/src/WidgetDepot.Web/Program.cs
@@ -41,6 +41,13 @@ builder.Services.AddApiHttpClients();
 
 builder.Services.AddScoped<OrderWizardState>();
 
+if (builder.Environment.IsDevelopment())
+{
+    builder.Services
+        .AddHttpClient("test-api", c => c.BaseAddress = new Uri("https+http://apiservice"))
+        .AddHttpMessageHandler<CookieForwardingHandler>();
+}
+
 var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())
@@ -65,6 +72,21 @@ app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 
 app.MapDefaultEndpoints();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapPost("/test/problem-reports", async (
+        TestProblemReportBody body,
+        IHttpClientFactory httpClientFactory,
+        CancellationToken cancellationToken) =>
+    {
+        var client = httpClientFactory.CreateClient("test-api");
+        var response = await client.PostAsJsonAsync("/test/problem-reports", body, cancellationToken);
+        return response.IsSuccessStatusCode
+            ? Results.Ok(await response.Content.ReadFromJsonAsync<object>(cancellationToken))
+            : Results.Problem();
+    }).RequireAuthorization();
+}
 
 app.MapGet("/accounts/do-signin", async (HttpContext context, int customerId, string email, string firstName, bool isAdmin, bool mustChangePassword, string? returnUrl) =>
 {
@@ -101,3 +123,5 @@ app.MapGet("/accounts/logout", async (HttpContext context) =>
 });
 
 app.Run();
+
+record TestProblemReportBody(int OrderId);

--- a/tests/WidgetDepot.E2E/tests/my-problem-reports.spec.ts
+++ b/tests/WidgetDepot.E2E/tests/my-problem-reports.spec.ts
@@ -11,6 +11,13 @@ test.describe('My Problem Reports (unauthenticated)', () => {
 });
 
 test.describe('My Problem Reports', () => {
+  test.beforeEach(async ({ page }) => {
+    if (!process.env.E2E_SUBMITTED_ORDER_NUMBER) return;
+    await page.request.post('/test/problem-reports', {
+      data: { orderId: Number(process.env.E2E_SUBMITTED_ORDER_NUMBER) },
+    });
+  });
+
   // AC: An authenticated customer can access the "My Problem Reports" page
   test('authenticated user can access the page', async ({ myProblemReportsPage }) => {
     await myProblemReportsPage.goto();
@@ -36,7 +43,7 @@ test.describe('My Problem Reports', () => {
 
   // AC: Reports where EmailSent = false display a "Resend email" button
   test('shows Resend email button for reports with email not sent', async ({ myProblemReportsPage }) => {
-    test.skip(!process.env.E2E_PROBLEM_REPORT_UNSENT_EMAIL, 'E2E_PROBLEM_REPORT_UNSENT_EMAIL not set');
+    test.skip(!process.env.E2E_SUBMITTED_ORDER_NUMBER, 'E2E_SUBMITTED_ORDER_NUMBER not set');
 
     await myProblemReportsPage.goto();
     await myProblemReportsPage.waitForReady();


### PR DESCRIPTION
## Summary

- The `'shows Resend email button for reports with email not sent'` test was relying on a pre-existing `EmailSent = false` record in the database, which doesn't exist when the local email service (Mailpit) is running and successfully delivers every submitted problem report
- Added a development-only `POST /test/problem-reports` endpoint to the ApiService that inserts a `ProblemReport` with `EmailSent = false` directly, bypassing the email step
- Added a proxy `POST /test/problem-reports` route to the Web project (dev only) so Playwright can reach the ApiService endpoint through the normal base URL using the authenticated browser session
- Updated the test to call the proxy in `beforeEach`, ensuring a fresh unsent report always exists before the assertion runs; removed the now-redundant `E2E_PROBLEM_REPORT_UNSENT_EMAIL` guard

## Test plan

- [ ] `dotnet build` passes with no warnings or errors
- [ ] Run `npm test --prefix tests/WidgetDepot.E2E` — `'shows Resend email button for reports with email not sent'` now passes consistently even when Mailpit is running
- [ ] Confirm the test does not skip when `E2E_PROBLEM_REPORT_UNSENT_EMAIL` is absent from `.env`
- [ ] Verify the other `My Problem Reports` tests are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)